### PR TITLE
feat(pp): add summarize_peptides_by_neighbourhood_union

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,32 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Preprocessing** (`pr.pp`): `summarize_peptides_by_neighbourhood_union()`
+  collapses peptides that overlap in the protein sequence, keeping the
+  most abundant member of each group. Peptide positions are resolved
+  from a FASTA in the same call. A reimplementation of CCprofiler's
+  `summarizeAlternativePeptideSequences(topN = 1)`.
+  - groups by positional overlap rather than substring containment, so
+    it sees peptide pairs that overlap without either containing the
+    other, and needs no separate modification-summarisation step
+  - selects the most abundant member instead of aggregating; `top_n`
+    sums the leading members instead, with `keep_less` controlling
+    undersized groups
+  - missing values are deprioritised rather than removed: an
+    incomplete peptide sorts last and loses to any complete
+    competitor, but survives if its group has no complete member
+  - equal totals are resolved by `tie_break_key`, so the result does
+    not depend on input row order; `letters_first_key` is the default
+  - `on_unknown_protein` and `on_unlocated_peptide` decide whether an
+    unresolvable position raises, skips the peptide, or leaves the
+    position undefined
+  - `.var` is reduced to the peptide-level proteodata columns plus the
+    function's own output, since the surviving row's annotations
+    describe one member rather than the group; `keep_var_cols` carries
+    chosen columns through, aggregated across the group
+
 ### Fixed
 
 - **Datasets** (`pr.datasets`) and **Download** (`pr.download`):

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,7 +24,8 @@ and this project adheres to
     incomplete peptide sorts last and loses to any complete
     competitor, but survives if its group has no complete member
   - equal totals are resolved by `tie_break_key`, so the result does
-    not depend on input row order; `letters_first_key` is the default
+    not depend on input row order; the default sorts non-letters after
+    letters, favouring the unmodified form of an identifier
   - `on_unknown_protein` and `on_unlocated_peptide` decide whether an
     unresolvable position raises, skips the peptide, or leaves the
     position undefined

--- a/docs/sphinx/source/api/pp.rst
+++ b/docs/sphinx/source/api/pp.rst
@@ -48,7 +48,6 @@ filtering, normalization, and imputation of proteomics data.
    proteopy.pp.summarize_modifications
    proteopy.pp.summarize_overlapping_peptides
    proteopy.pp.summarize_peptides_by_neighbourhood_union
-   proteopy.pp.letters_first_key
    proteopy.pp.quantify_proteins
    proteopy.pp.quantify_proteoforms
 

--- a/docs/sphinx/source/api/pp.rst
+++ b/docs/sphinx/source/api/pp.rst
@@ -47,6 +47,8 @@ filtering, normalization, and imputation of proteomics data.
    proteopy.pp.extract_peptide_groups
    proteopy.pp.summarize_modifications
    proteopy.pp.summarize_overlapping_peptides
+   proteopy.pp.summarize_peptides_by_neighbourhood_union
+   proteopy.pp.letters_first_key
    proteopy.pp.quantify_proteins
    proteopy.pp.quantify_proteoforms
 

--- a/proteopy/pp/__init__.py
+++ b/proteopy/pp/__init__.py
@@ -27,7 +27,6 @@ from .quantification import (
 )
 
 from .summarize_peptides_by_neighbourhood_union import (
-    letters_first_key,
     summarize_peptides_by_neighbourhood_union,
 )
 

--- a/proteopy/pp/__init__.py
+++ b/proteopy/pp/__init__.py
@@ -7,15 +7,15 @@ from .filtering import (
     filter_samples_by_category_count,
     remove_zero_variance_vars,
     remove_contaminants,
-    )
+)
 
 from .imputation import (
     impute_downshift,
-    )
+)
 
 from .normalization import (
     normalize_median,
-    )
+)
 
 from .quantification import (
     extract_peptide_groups,
@@ -24,6 +24,11 @@ from .quantification import (
     quantify_by_category,
     quantify_proteins,
     quantify_proteoforms,
-    )
+)
+
+from .summarize_peptides_by_neighbourhood_union import (
+    letters_first_key,
+    summarize_peptides_by_neighbourhood_union,
+)
 
 from .stats import calculate_cv

--- a/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
+++ b/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
@@ -1,0 +1,715 @@
+"""Peptide summarisation by positional neighbourhood union.
+
+Reimplementation of CCprofiler's
+``summarizeAlternativePeptideSequences(topN = 1)`` together with the
+``proteinQuantification(topN, keep_less)`` selection it delegates to.
+Reference source: CCprofiler at git ref ``31a3043`` (branch
+``proteoformLocationMapping``), files ``R/summarizeRedundantPeptides.R``
+and ``R/proteinQuantification.R``.
+
+The algorithm has three layers, and the terms are used consistently
+throughout this module:
+
+**neighbourhood**
+    ``coPeps(x)`` -- the peptides ``q`` of the same protein whose start
+    OR end position falls inside ``x``'s interval.
+**label**
+    the union of every neighbourhood that contains ``x``.
+**group**
+    all peptides carrying an identical label. Exactly one row survives
+    per group.
+
+This is not the same grouping as
+:func:`~proteopy.pp.summarize_overlapping_peptides`, which uses
+substring containment and aggregates. Here peptides are grouped by
+their positions in the protein sequence, and the most abundant member
+is *selected* while the rest are discarded.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+from collections.abc import Callable, Iterable
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+from proteopy.pp.quantification import _rebuild_adata
+from proteopy.utils.anndata import check_proteodata
+
+# IUPAC one-letter codes. Broader than the canonical twenty on purpose:
+# UniProt sequences legitimately contain U (selenocysteine) and the
+# ambiguity codes B, J, O, X and Z, and rejecting them would turn a
+# real selenopeptide into a false error. Every modification notation
+# character -- digits, brackets, parentheses, +, -, lowercase markers --
+# is still outside this set.
+IUPAC_AMINO_ACIDS = "ACDEFGHIKLMNPQRSTVWYBJOUXZ"
+
+# What CCprofiler hard-codes in getPepStartSite and in the
+# PeptidePositionEnd calculation.
+CCPROFILER_MOD_REGEX = r"\(UniMod:[0-9]+\)"
+
+# names(fasta) = gsub(".*\\|(.*?)\\|.*", "\\1", names(fasta)) -- pulls the
+# accession out of a `sp|ACC|NAME description` header. Replicated rather
+# than improved: a header whose description contains a pipe is handled
+# the same (mis)way as the reference.
+_FASTA_ACCESSION_RE = re.compile(r".*\|(.*?)\|.*")
+
+_UNRESOLVED_MODES = ("raise", "skip", "keep")
+_ID_FROM_MODES = ("top_ranked",)
+
+_START_COL = "peptide_start"
+_END_COL = "peptide_end"
+_N_COL = "n_grouped"
+
+
+def letters_first_key(peptide_id: str) -> tuple:
+    """Ordering key placing letters before any non-letter character.
+
+    Under plain codepoint order ``(`` sorts before ``A`` while ``[``
+    sorts after ``Z``, so the two common modification notations would
+    break ties in opposite directions. This key makes both land after
+    the letters, so an unmodified identifier wins a tie against any
+    annotated form of itself.
+
+    Parameters
+    ----------
+    peptide_id : str
+        Peptide identifier.
+
+    Returns
+    -------
+    tuple
+        Per-character sort key.
+    """
+    return tuple(
+        (0, char) if char.isalpha() else (1, char) for char in peptide_id
+    )
+
+
+def _validate_arguments(
+    top_n,
+    keep_less,
+    id_from,
+    on_unknown_protein,
+    on_unlocated_peptide,
+    tie_break_key,
+    zero_to_na,
+    fill_na,
+):
+    """Check every argument before any work is done."""
+    if not isinstance(top_n, (int, np.integer)) or top_n < 1:
+        raise ValueError(f"top_n must be an integer >= 1, got {top_n!r}.")
+    if not isinstance(keep_less, bool):
+        raise TypeError(
+            f"keep_less must be bool, got {type(keep_less).__name__}."
+        )
+    if id_from not in _ID_FROM_MODES:
+        raise ValueError(
+            f"id_from must be one of {_ID_FROM_MODES!r}, got "
+            f"{id_from!r}. Only 'top_ranked' is implemented; other "
+            "naming schemes may be added later."
+        )
+    for name, value in (
+        ("on_unknown_protein", on_unknown_protein),
+        ("on_unlocated_peptide", on_unlocated_peptide),
+    ):
+        if value not in _UNRESOLVED_MODES:
+            raise ValueError(
+                f"{name} must be one of {_UNRESOLVED_MODES!r}, "
+                f"got {value!r}."
+            )
+    if not callable(tie_break_key):
+        raise TypeError("tie_break_key must be callable.")
+    if not isinstance(zero_to_na, bool):
+        raise TypeError(
+            f"zero_to_na must be bool, " f"got {type(zero_to_na).__name__}."
+        )
+    if fill_na is not None and (
+        isinstance(fill_na, bool) or not isinstance(fill_na, (int, float))
+    ):
+        raise TypeError(
+            f"fill_na must be float, int, or None, "
+            f"got {type(fill_na).__name__}."
+        )
+    if zero_to_na and fill_na is not None:
+        raise ValueError("`zero_to_na` and `fill_na` are mutually exclusive.")
+
+
+def _validate_var(adata, peptide_col, protein_col, written_cols):
+    """Check the required columns exist and the written ones do not."""
+    for col in (peptide_col, protein_col):
+        if col not in adata.var.columns:
+            raise KeyError(f"'{col}' not found in adata.var")
+
+    clashes = [c for c in written_cols if c in adata.var.columns]
+    if clashes:
+        raise ValueError(
+            "adata.var already contains column(s) that this function "
+            f"writes: {', '.join(repr(c) for c in clashes)}. Rename or "
+            "drop them first, or pass a different `key_added`. This is "
+            "refused rather than overwritten so a second call cannot "
+            "silently discard an earlier annotation."
+        )
+
+
+def _read_fasta(path: str | Path) -> dict[str, str]:
+    """Read a FASTA into ``{accession: sequence}``.
+
+    Header handling replicates CCprofiler's: the accession is extracted
+    with ``.*\\|(.*?)\\|.*`` and a header that does not match is used
+    verbatim. Duplicate accessions keep the FIRST occurrence, matching
+    Biostrings' name-based subsetting.
+    """
+    sequences: dict[str, str] = {}
+    header, chunks = None, []
+
+    def flush():
+        if header is not None and header not in sequences:
+            sequences[header] = "".join(chunks)
+
+    with open(path) as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                flush()
+                header = _FASTA_ACCESSION_RE.sub(r"\1", line[1:])
+                chunks = []
+            else:
+                chunks.append(line)
+    flush()
+    return sequences
+
+
+def _resolve_annotator(annotator) -> dict[str, str]:
+    """Accept a FASTA path or an already-parsed sequence mapping."""
+    if isinstance(annotator, (str, Path)):
+        return _read_fasta(annotator)
+    if isinstance(annotator, dict):
+        return {str(k): str(v) for k, v in annotator.items()}
+    raise TypeError(
+        "annotator must be a path to a FASTA file or a "
+        "{accession: sequence} mapping, got "
+        f"{type(annotator).__name__}."
+    )
+
+
+def _strip_and_validate(peptides, pattern, allowed):
+    """Strip annotations and check what remains is amino acids only.
+
+    This is what makes ``mod_regex`` self-checking: the caller declares
+    what to disregard and the alphabet verifies the declaration was
+    complete, so no notation-specific pattern has to be hard-coded to
+    recognise mass shifts, bracket tags or lowercase markers.
+    """
+    stripped = [pattern.sub("", pid) for pid in peptides]
+
+    offenders = []
+    for pid, seq in zip(peptides, stripped):
+        residual = sorted({c for c in seq if c not in allowed})
+        if residual:
+            offenders.append((pid, residual))
+
+    if offenders:
+        shown = "\n".join(
+            f"  {pid}  ->  residual characters: "
+            + ", ".join(repr(c) for c in residual)
+            for pid, residual in offenders[:20]
+        )
+        more = (
+            f"\n  ... and {len(offenders) - 20} more"
+            if len(offenders) > 20
+            else ""
+        )
+        raise ValueError(
+            f"{len(offenders)} peptide identifier(s) still contain "
+            "characters that are not amino acids after `mod_regex` "
+            f"was applied:\n{shown}{more}\n"
+            "Widen `mod_regex` so it matches every annotation to "
+            "disregard, or pass a different `alphabet`."
+        )
+    return stripped
+
+
+def _locate(
+    peptides,
+    stripped,
+    proteins,
+    sequences,
+    on_unknown_protein,
+    on_unlocated_peptide,
+):
+    """Resolve 1-based inclusive positions, applying both policies.
+
+    Returns ``(starts, ends, keep)`` where ``keep`` is a boolean mask of
+    the peptides that remain in the analysis. Unresolvable positions are
+    ``NaN``, which is what makes them compare False against every
+    interval and collapse into the empty label.
+    """
+    n = len(peptides)
+    starts = np.full(n, np.nan)
+    keep = np.ones(n, dtype=bool)
+
+    # --- proteins absent from the annotator
+    missing = sorted({p for p in proteins if p not in sequences})
+    if missing:
+        if on_unknown_protein == "raise":
+            shown = ", ".join(missing[:20])
+            more = (
+                f" ... and {len(missing) - 20} more"
+                if len(missing) > 20
+                else ""
+            )
+            raise ValueError(
+                f"{len(missing)} protein(s) in adata.var are absent "
+                f"from `annotator`: {shown}{more}. Set "
+                "on_unknown_protein='skip' to discard their peptides, "
+                "or on_unknown_protein='keep' to give them NaN "
+                "positions, which is the CCprofiler behaviour."
+            )
+        absent = np.array([p in missing for p in proteins], dtype=bool)
+        if on_unknown_protein == "skip":
+            keep &= ~absent
+
+    # --- locate each (protein, stripped peptide) pair once, as
+    #     CCprofiler does via `by = c("id", "protein_id")`
+    cache: dict[tuple, float] = {}
+    for i in range(n):
+        if not keep[i]:
+            continue
+        key = (proteins[i], stripped[i])
+        if key not in cache:
+            seq = sequences.get(proteins[i])
+            if seq is None:
+                cache[key] = np.nan
+            else:
+                found = seq.find(stripped[i])
+                cache[key] = np.nan if found < 0 else float(found + 1)
+        starts[i] = cache[key]
+
+    # --- peptides whose protein IS present but whose sequence is not
+    present = np.array([p in sequences for p in proteins], dtype=bool)
+    unlocated = keep & present & np.isnan(starts)
+    if unlocated.any():
+        if on_unlocated_peptide == "raise":
+            idx = np.flatnonzero(unlocated)
+            shown = "\n".join(
+                f"  {peptides[i]} (protein {proteins[i]})" for i in idx[:20]
+            )
+            more = f"\n  ... and {len(idx) - 20} more" if len(idx) > 20 else ""
+            raise ValueError(
+                f"{int(unlocated.sum())} peptide(s) were not found in "
+                f"their protein sequence:\n{shown}{more}\n"
+                "Set on_unlocated_peptide='skip' to discard them, or "
+                "on_unlocated_peptide='keep' to give them NaN "
+                "positions, which is the CCprofiler behaviour."
+            )
+        if on_unlocated_peptide == "skip":
+            keep &= ~unlocated
+
+    lengths = np.array([len(s) for s in stripped], dtype=float)
+    ends = starts + lengths - 1.0
+    return starts, ends, keep
+
+
+def _neighbourhood_union_labels(starts, ends, ids):
+    """CCprofiler's positional group label, for one protein.
+
+    Replicates, verbatim in behaviour::
+
+        coPeps <- subset(p_ann,
+            ((p_ann[[start]] >= pep_ann[[start]]) &
+             (p_ann[[start]] <= pep_ann[[end]])) |
+            (p_ann[[end]]   >= pep_ann[[start]]) &
+            (p_ann[[end]]   <= pep_ann[[end]]))$id
+        new_id <- paste0(sort(unique(unlist(
+            lapply(pep_seq, function(x) if (pep %in% x) x)))),
+            collapse = ";")
+
+    Two properties are load-bearing and must not be "fixed":
+
+    * **The overlap test is asymmetric.** ``coPeps(x)`` asks only
+      whether the *other* peptide's start or end falls inside ``x``'s
+      interval, so a strictly-enclosed neighbour is visible from one
+      side only. (This turns out to be unobservable in the output: when
+      ``q`` is strictly inside ``x`` then ``coPeps(q)`` is a subset of
+      ``coPeps(x)``, so the missing edge adds nothing to any union.)
+    * **The label is a one-hop union, not a transitive closure.** An
+      overlap chain ``A-B-C-D`` with only adjacent pairs overlapping
+      yields THREE groups -- ``{A}``, ``{B, C}``, ``{D}`` -- because the
+      two interior peptides each sit in three neighbourhoods and so take
+      the full union. Transitive closure would give one group and select
+      one peptide where the reference selects three.
+
+    Peptides whose positions are ``NaN`` compare False against
+    everything, so they receive the empty label and collapse into a
+    single group per protein. That is the reference's behaviour, and it
+    is how a protein absent from the FASTA is stripped to one peptide.
+    """
+    n = len(ids)
+    if n == 0:
+        return []
+
+    s = np.asarray(starts, dtype=float)
+    e = np.asarray(ends, dtype=float)
+
+    # member[j, k] is True  <=>  ids[k] in coPeps(ids[j]).
+    # Comparisons against NaN are False, matching what R's subset does
+    # with an NA condition.
+    with np.errstate(invalid="ignore"):
+        member = ((s[None, :] >= s[:, None]) & (s[None, :] <= e[:, None])) | (
+            (e[None, :] >= s[:, None]) & (e[None, :] <= e[:, None])
+        )
+
+    # union[i, k] is True <=> some j has both i and k in coPeps(j),
+    # which is the boolean matrix product member.T @ member. float32 is
+    # exact here: the counts are bounded by n, far below 2**24.
+    counts = member.astype(np.float32)
+    union = (counts.T @ counts) > 0
+
+    return [
+        ";".join(sorted(ids[k] for k in np.flatnonzero(union[i])))
+        for i in range(n)
+    ]
+
+
+def _group_keys(starts, ends, ids, proteins):
+    """Assign every peptide a ``(protein, label)`` group key.
+
+    Grouping is confined to a protein, exactly as
+    ``protein_id := paste0(protein_id, "_", new_id)`` does.
+    """
+    keys = np.empty(len(ids), dtype=object)
+    order = pd.Series(range(len(proteins)))
+    for _, idx in order.groupby(proteins, sort=False):
+        rows = idx.to_numpy()
+        labels = _neighbourhood_union_labels(
+            starts[rows], ends[rows], list(ids[rows])
+        )
+        for row, label in zip(rows, labels):
+            keys[row] = (proteins[row], label)
+    return keys
+
+
+def _select(keys, totals, ids, top_n, keep_less, tie_break_key):
+    """Rank each group and pick its representative and contributors.
+
+    The rank reproduces ``peptide_intensity := sum(intensity)`` under
+    ``na.rm = FALSE`` followed by ``rank(-peptide_intensity)`` under
+    ``na.last = TRUE``: a peptide with any missing sample has a NaN
+    total and ranks LAST. Equal totals are then resolved by
+    ``tie_break_key`` rather than by row order, so the result does not
+    depend on how the input table happened to be sorted.
+    """
+    is_nan = np.isnan(totals)
+    tie_keys = [tie_break_key(pid) for pid in ids]
+
+    def rank_key(i):
+        if is_nan[i]:
+            return (1, 0.0, tie_keys[i])
+        return (0, -float(totals[i]), tie_keys[i])
+
+    members: dict[Any, list] = {}
+    for i, key in enumerate(keys):
+        members.setdefault(key, []).append(i)
+
+    selections = []
+    for key, rows in members.items():
+        if len(rows) < top_n and not keep_less:
+            continue
+        ranked = sorted(rows, key=rank_key)
+        selections.append(
+            {
+                "representative": ranked[0],
+                "contributors": ranked[:top_n],
+                "members": rows,
+            }
+        )
+    return selections
+
+
+def summarize_peptides_by_neighbourhood_union(
+    adata: ad.AnnData,
+    annotator: str | Path | dict[str, str],
+    *,
+    protein_col: str = "protein_id",
+    peptide_col: str = "peptide_id",
+    top_n: int = 1,
+    keep_less: bool = False,
+    id_from: str = "top_ranked",
+    mod_regex: str = CCPROFILER_MOD_REGEX,
+    alphabet: Iterable[str] = IUPAC_AMINO_ACIDS,
+    on_unknown_protein: str = "raise",
+    on_unlocated_peptide: str = "raise",
+    tie_break_key: Callable[[str], Any] = letters_first_key,
+    zero_to_na: bool = False,
+    fill_na: float | int | None = None,
+    sort_descending_id: bool = True,
+    key_added: str = "peptide_ids",
+    inplace: bool = True,
+    verbose: bool = False,
+) -> ad.AnnData | None:
+    """
+    Collapse peptides that overlap in the protein sequence.
+
+    Reimplements CCprofiler's
+    ``summarizeAlternativePeptideSequences(topN = 1)``. Peptide
+    positions are resolved from ``annotator``, peptides are grouped by
+    the union of their positional neighbourhoods, and the most abundant
+    member of each group is selected while the rest are discarded.
+
+    Unlike :func:`~proteopy.pp.summarize_overlapping_peptides`, which
+    groups by substring containment and aggregates, this function
+    selects. It also needs no separate modification-summarisation step:
+    two peptidoforms of one stripped sequence share an interval, so they
+    group and one is selected.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Peptide-level data. Only ``.X`` is read and written.
+    annotator : str | Path | dict
+        Path to a FASTA file, or a pre-parsed
+        ``{accession: sequence}`` mapping, supplying the protein
+        sequences that peptide positions are resolved against.
+    protein_col, peptide_col : str, optional
+        Columns in ``.var`` holding the protein and peptide
+        identifiers.
+    top_n : int, optional
+        How many of each group's most abundant members contribute to
+        the output value. ``1`` selects a single peptide and copies its
+        intensities; above ``1`` the selected members are summed.
+    keep_less : bool, optional
+        If False, discard groups with fewer than ``top_n`` members. Has
+        no effect at ``top_n=1``, since every group has a member.
+    id_from : {'top_ranked'}, optional
+        How the surviving row is identified. Only ``'top_ranked'`` is
+        implemented: the row takes the identifier of the group's most
+        abundant member. This deviates from CCprofiler, which renames
+        the row to a comma-joined list of the summed identifiers and
+        thereby breaks its own annotation join.
+    mod_regex : str, optional
+        Everything in an identifier that is not protein sequence. The
+        pattern must cover *every* annotation present; whatever it fails
+        to match is searched for verbatim, and the ``alphabet`` check
+        turns an incomplete pattern into an error rather than a silently
+        unlocatable peptide.
+    alphabet : iterable of str, optional
+        Characters permitted in a stripped identifier. Defaults to the
+        IUPAC one-letter codes, which include selenocysteine and the
+        ambiguity codes.
+    on_unknown_protein : {'raise', 'skip', 'keep'}, optional
+        What to do with a protein absent from ``annotator``.
+        ``'skip'`` discards its peptides; ``'keep'`` gives them NaN
+        positions, so they share the empty label, collapse into one
+        group, and the single survivor is removed downstream by a
+        peptide-count filter. ``'keep'`` is the CCprofiler behaviour.
+    on_unlocated_peptide : {'raise', 'skip', 'keep'}, optional
+        What to do with a peptide whose sequence does not occur in its
+        protein. ``'keep'`` is the CCprofiler behaviour, which is
+        silent about this case; ``'raise'`` is the default because that
+        silence is the reference's real blind spot.
+    tie_break_key : callable, optional
+        Key applied to the peptide identifier to resolve equal totals.
+        Defaults to :func:`letters_first_key`, which places ``(`` and
+        ``[`` after the letters so an unmodified identifier wins.
+    zero_to_na : bool, optional
+        If True, treat zeros as missing before ranking.
+    fill_na : float | int | None, optional
+        Replace missing values with this constant before ranking.
+        Mutually exclusive with ``zero_to_na``. Note that ``0`` is not
+        faithful: it gives an incomplete peptide a real total and can
+        win it a ranking it should have lost.
+    sort_descending_id : bool, optional
+        Order output variables by descending identifier, matching the
+        reference's closing ``setorder(traces, -id)``. Row order is
+        load-bearing downstream, where average-linkage clustering breaks
+        its own ties by row order.
+    key_added : str, optional
+        ``.var`` column receiving the ``';'``-joined identifiers of all
+        group members.
+    inplace : bool, optional
+        If True, modify ``adata`` in place. Otherwise return a new
+        AnnData.
+    verbose : bool, optional
+        Print a peptide-count summary.
+
+    Returns
+    -------
+    AnnData or None
+        The summarised object when ``inplace=False``, otherwise None.
+
+        ``.var`` is reduced to ``peptide_id``, ``protein_id``,
+        ``peptide_start``, ``peptide_end``, ``key_added`` and
+        ``n_grouped``. Other annotations are dropped: the surviving
+        row's metadata is one member's, not the group's, and carrying
+        it would invite it to be read as representative. Layers are
+        dropped for the same reason.
+
+    Raises
+    ------
+    ValueError
+        If an argument is invalid; if ``.var`` already holds a column
+        this function writes; if a stripped identifier contains
+        non-amino-acid characters; or, under the default policies, if a
+        protein is absent from ``annotator`` or a peptide is not found
+        in its protein sequence.
+
+    Examples
+    --------
+    Positional overlap groups peptides that substring containment
+    cannot see: ``ABCDEF`` and ``DEFGHI`` overlap in the protein but
+    neither contains the other.
+
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from anndata import AnnData
+    >>> import proteopy as pr
+    >>> pids = ["ABCDEF", "DEFGHI"]
+    >>> var = pd.DataFrame(
+    ...     {"peptide_id": pids, "protein_id": ["P1", "P1"]},
+    ...     index=pids,
+    ... )
+    >>> obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
+    >>> adata = AnnData(
+    ...     X=np.array([[10.0, 99.0]]), obs=obs, var=var,
+    ... )
+    >>> out = pr.pp.summarize_peptides_by_neighbourhood_union(
+    ...     adata, {"P1": "ABCDEFGHI"}, inplace=False,
+    ... )
+    >>> out.var_names.tolist()
+    ['DEFGHI']
+    >>> out.X
+    array([[99.]])
+    """
+    # -- validate everything before doing any work
+    _validate_arguments(
+        top_n,
+        keep_less,
+        id_from,
+        on_unknown_protein,
+        on_unlocated_peptide,
+        tie_break_key,
+        zero_to_na,
+        fill_na,
+    )
+    written = (_START_COL, _END_COL, key_added, _N_COL)
+    _validate_var(adata, peptide_col, protein_col, written)
+    check_proteodata(adata)
+
+    sequences = _resolve_annotator(annotator)
+    pattern = re.compile(mod_regex)
+    allowed = frozenset(alphabet)
+
+    peptides = adata.var[peptide_col].astype(str).to_numpy()
+    proteins = adata.var[protein_col].astype(str).to_numpy()
+
+    stripped = _strip_and_validate(peptides, pattern, allowed)
+    starts, ends, keep = _locate(
+        peptides,
+        stripped,
+        proteins,
+        sequences,
+        on_unknown_protein,
+        on_unlocated_peptide,
+    )
+
+    # -- matrix, densified; only .X is read
+    was_sparse = sparse.issparse(adata.X)
+    X = adata.X.toarray() if was_sparse else np.asarray(adata.X)
+    X = X.astype(float, copy=True)
+    if zero_to_na:
+        X[X == 0] = np.nan
+    if fill_na is not None:
+        X[np.isnan(X)] = fill_na
+
+    # -- restrict to the peptides that survived the two policies
+    kept = np.flatnonzero(keep)
+    X = X[:, kept]
+    peptides, proteins = peptides[kept], proteins[kept]
+    starts, ends = starts[kept], ends[kept]
+
+    # A plain sum, so NaN propagates -- an incomplete peptide gets a NaN
+    # total and ranks last.
+    totals = X.sum(axis=0) if X.size else np.zeros(len(kept))
+
+    keys = _group_keys(starts, ends, peptides, proteins)
+    selections = _select(
+        keys, totals, peptides, top_n, keep_less, tie_break_key
+    )
+
+    # -- assemble the surviving rows
+    if sort_descending_id:
+        # setorder(traces, -id). data.table sorts character in the C
+        # locale and Python compares by codepoint, which agree for
+        # ASCII peptide identifiers.
+        selections.sort(
+            key=lambda s: peptides[s["representative"]], reverse=True
+        )
+    else:
+        selections.sort(key=lambda s: s["representative"])
+
+    columns, records = [], []
+    for sel in selections:
+        rep = sel["representative"]
+        contributors = sel["contributors"]
+        if len(contributors) == 1:
+            values = X[:, contributors[0]]
+        else:
+            values = X[:, contributors].sum(axis=1)
+        columns.append(values)
+        records.append(
+            {
+                peptide_col: peptides[rep],
+                protein_col: proteins[rep],
+                _START_COL: starts[rep],
+                _END_COL: ends[rep],
+                key_added: ";".join(
+                    sorted(peptides[i] for i in sel["members"])
+                ),
+                _N_COL: len(sel["members"]),
+            }
+        )
+
+    if columns:
+        X_new = np.column_stack(columns)
+    else:
+        X_new = np.empty((adata.n_obs, 0), dtype=float)
+
+    var_new = pd.DataFrame(
+        records,
+        columns=[
+            peptide_col,
+            protein_col,
+            _START_COL,
+            _END_COL,
+            key_added,
+            _N_COL,
+        ],
+    )
+    var_new[_START_COL] = var_new[_START_COL].astype(float)
+    var_new[_END_COL] = var_new[_END_COL].astype(float)
+    var_new[_N_COL] = var_new[_N_COL].astype(int)
+    # A plain list, not the Series: pd.Index() inherits a Series' name
+    # even when name=None is passed, and a named var index turns
+    # `.reset_index()` into a differently-named column downstream.
+    var_new.index = pd.Index([str(v) for v in var_new[peptide_col]])
+    var_new.index.name = None
+
+    if verbose:
+        print(
+            f"summarize_peptides_by_neighbourhood_union: "
+            f"{adata.n_vars} -> {var_new.shape[0]} peptides across "
+            f"{len(selections)} neighbourhood group(s)"
+        )
+
+    if was_sparse:
+        X_new = sparse.csr_matrix(X_new)
+
+    result = _rebuild_adata(adata, X_new, var_new, inplace)
+    check_proteodata(adata if inplace else result)
+    return result

--- a/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
+++ b/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
@@ -1,119 +1,3 @@
-"""Peptide summarisation by positional neighbourhood union.
-
-Reimplementation of CCprofiler's
-``summarizeAlternativePeptideSequences(topN = 1)`` together with the
-``proteinQuantification(topN, keep_less)`` selection it delegates to.
-
-Reference source
-    https://github.com/CCprofiler/CCprofiler/tree/proteoformLocationMapping
-
-    Branch ``proteoformLocationMapping``, git ref ``31a3043``, files
-    ``R/summarizeRedundantPeptides.R`` and ``R/proteinQuantification.R``.
-    Note this is a branch, not a release tag: the functions below are
-    absent from ``v1.0.1-copf``.
-
-Algorithm
----------
-Peptides are handled one protein at a time. Let ``P`` be the peptides
-of a protein. Each ``x`` in ``P`` carries a closed, 1-based interval
-``[s(x), e(x)]`` locating where its modification-stripped sequence
-first occurs in the protein sequence, or ``UNDEF`` when the sequence
-cannot be located there at all.
-
-**Membership.** The neighbourhood of ``x`` is every peptide whose start
-or end falls inside ``x``'s interval::
-
-    N(x) = { q in P : s(q) in [s(x), e(x)]  or  e(q) in [s(x), e(x)] }
-
-Every comparison involving ``UNDEF`` is false, so an unlocated peptide
-belongs to no neighbourhood and its own neighbourhood is empty.
-
-``N`` is deliberately **not symmetric**. If ``q`` lies strictly inside
-``x`` then ``q`` is in ``N(x)`` but ``x`` is not in ``N(q)``, because
-the test only asks where the *other* peptide's endpoints land.
-
-**Label.** The label of ``x`` is the union of every neighbourhood that
-contains it — a one-hop union, *not* a transitive closure::
-
-    L(x) = union of { N(y) : y in P and x in N(y) }
-
-**Group.** Peptides carrying the same label form a group::
-
-    G(x) = { q in P : L(q) = L(x) }
-
-**Selection.** With ``T(x)`` the total intensity of ``x`` summed over
-all samples, propagating missing values, the members of a group are
-ordered by::
-
-    key(x) = ( T(x) is missing,  -T(x),  tie_break_key(id(x)) )
-
-Complete peptides come first, then descending abundance, then a
-deterministic tie-break on the identifier. The leading ``top_n``
-members are kept and the rest discarded, so exactly one row survives
-per group.
-
-Worked example
---------------
-Protein ``ACDEFGHIKLMNPQRSTVWY`` with five peptides: a chain of four in
-which only adjacent pairs overlap, plus ``CDE`` lying strictly inside
-``ACDEF``::
-
-    ACDEF [1, 5]   EFGHI [4, 8]   HIKLM [7, 11]   LMNPQ [10, 14]
-    CDE   [2, 4]
-
-    N(ACDEF) = {ACDEF, CDE, EFGHI}
-    N(CDE)   = {CDE, EFGHI}                 <- ACDEF absent: N is asymmetric
-    N(EFGHI) = {ACDEF, CDE, EFGHI, HIKLM}
-    N(HIKLM) = {EFGHI, HIKLM, LMNPQ}
-    N(LMNPQ) = {HIKLM, LMNPQ}
-
-    L(ACDEF) = L(CDE)   = {ACDEF, CDE, EFGHI, HIKLM}
-    L(EFGHI) = L(HIKLM) = {ACDEF, CDE, EFGHI, HIKLM, LMNPQ}
-    L(LMNPQ)            = {EFGHI, HIKLM, LMNPQ}
-
-    G1 = {ACDEF, CDE}    G2 = {EFGHI, HIKLM}    G3 = {LMNPQ}
-
-Three groups, so three peptides survive. Two properties are visible
-here and both are load-bearing:
-
-* ``CDE`` groups with the container it sits inside, even though the
-  membership relation between them runs one way only.
-* A transitive closure over the same overlaps would merge all five into
-  a single group and keep ONE peptide. The chain's two interior members
-  are what separate the rules: each sits in three neighbourhoods, so
-  each absorbs the whole set, while the two ends do not.
-
-Missing values
---------------
-A peptide with any missing sample has ``T(x)`` missing and sorts LAST,
-so any complete competitor beats it however small its observed values
-are. This is deprioritisation, not removal:
-
-* With a complete member present, that member wins and the incomplete
-  one is discarded like any other loser.
-* When **every** member is missing, all totals are missing, nothing
-  separates them on abundance, and ``tie_break_key`` alone decides. The
-  winner passes through with its missing values intact, for a later
-  completeness filter to act on.
-* At ``top_n = 1`` no arithmetic happens — the surviving row is copied
-  verbatim — so a missing value can be neither created nor spread.
-* At ``top_n > 1`` the selected rows are summed and missingness
-  **propagates**: a sample missing in any contributor is missing in the
-  result, and a group whose members are all missing sums to missing.
-
-Relationship to summarize_overlapping_peptides
-----------------------------------------------
-A different grouping and a different reduction.
-:func:`~proteopy.pp.summarize_overlapping_peptides` groups by substring
-containment and *aggregates* the members; this function groups by
-position in the protein sequence and *selects* among them. Positional
-overlap also sees pairs that containment cannot — ``ACDEF`` and
-``EFGHI`` above overlap in the protein while neither contains the
-other — and it needs no separate modification-summarisation step,
-because two peptidoforms of one stripped sequence share an interval and
-therefore a group.
-"""
-
 import re
 from pathlib import Path
 from typing import Any
@@ -575,19 +459,42 @@ def summarize_peptides_by_neighbourhood_union(
     verbose: bool = False,
 ) -> ad.AnnData | None:
     """
-    Collapse peptides that overlap in the protein sequence.
+    Collapse peptides by their position in the protein sequence.
 
     Reimplements CCprofiler's
-    ``summarizeAlternativePeptideSequences(topN = 1)``. Peptide
+    ``summarizeAlternativePeptideSequences(topN = 1)`` [1]_. Peptide
     positions are resolved from ``annotator``, peptides are grouped by
     the union of their positional neighbourhoods, and the most abundant
     member of each group is selected while the rest are discarded.
 
-    Unlike :func:`~proteopy.pp.summarize_overlapping_peptides`, which
-    groups by substring containment and aggregates, this function
-    selects. It also needs no separate modification-summarisation step:
-    two peptidoforms of one stripped sequence share an interval, so they
-    group and one is selected.
+    Grouping happens within a protein. Each peptide ``x`` carries the
+    closed 1-based interval ``[s(x), e(x)]`` where its
+    modification-stripped sequence first occurs, and any comparison
+    involving an unlocated peptide is false::
+
+        N(x) = { q : s(q) in [s(x), e(x)] or e(q) in [s(x), e(x)] }
+        L(x) = union of { N(y) : x in N(y) }
+        G(x) = { q : L(q) = L(x) }
+
+    ``N`` is asymmetric — a peptide lying strictly inside ``x`` is in
+    ``N(x)`` but not the reverse — and ``L`` is a one-hop union rather
+    than a transitive closure, so a chain of overlaps can yield several
+    groups instead of one. Unlocated peptides share the empty label and
+    so collapse into a single group per protein.
+
+    Members of a group are ordered by ``(T(x) is missing, -T(x),
+    tie_break_key(id(x)))``, where ``T(x)`` is the intensity of ``x``
+    summed over samples. The leading ``top_n`` are kept and one row
+    survives per group.
+
+    Missing values are deprioritised, not removed. ``T`` propagates
+    them, so an incomplete peptide sorts last and loses to any complete
+    competitor however small the competitor's values; when every member
+    is incomplete, ``tie_break_key`` alone decides and the winner passes
+    through with its missing values intact. At ``top_n = 1`` the
+    surviving row is copied verbatim, so nothing is created or spread;
+    at ``top_n > 1`` the sum propagates, and an all-missing group sums
+    to missing.
 
     Parameters
     ----------
@@ -682,55 +589,51 @@ def summarize_peptides_by_neighbourhood_union(
         protein is absent from ``annotator`` or a peptide is not found
         in its protein sequence.
 
+    See Also
+    --------
+    summarize_overlapping_peptides : groups by substring containment
+        and aggregates the members, rather than grouping by position
+        and selecting among them.
+
     Examples
     --------
-    The worked example from the module docstring: a chain of four
-    overlapping peptides, plus ``CDE`` lying strictly inside ``ACDEF``.
-    It yields three groups — ``{ACDEF, CDE}``, ``{EFGHI, HIKLM}`` and
-    ``{LMNPQ}`` — so three of the five peptides survive.
+    Four peptides forming a chain in which only adjacent pairs overlap,
+    plus ``CDE`` lying strictly inside ``ACDEF``. Three groups form —
+    ``{ACDEF, CDE}``, ``{EFGHI, HIKLM}`` and ``{LMNPQ}`` — so three of
+    the five peptides survive, each represented by its most abundant
+    member.
 
     >>> import numpy as np
     >>> import pandas as pd
     >>> from anndata import AnnData
     >>> import proteopy as pr
     >>> pids = ["ACDEF", "CDE", "EFGHI", "HIKLM", "LMNPQ"]
-    >>> var = pd.DataFrame(
-    ...     {"peptide_id": pids, "protein_id": ["P1"] * 5},
-    ...     index=pids,
-    ... )
-    >>> obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
     >>> adata = AnnData(
     ...     X=np.array([[30.0, 5.0, 20.0, 99.0, 40.0]]),
-    ...     obs=obs,
-    ...     var=var,
+    ...     obs=pd.DataFrame({"sample_id": ["s1"]}, index=["s1"]),
+    ...     var=pd.DataFrame(
+    ...         {"peptide_id": pids, "protein_id": ["P1"] * 5},
+    ...         index=pids,
+    ...     ),
     ... )
     >>> out = pr.pp.summarize_peptides_by_neighbourhood_union(
     ...     adata, {"P1": "ACDEFGHIKLMNPQRSTVWY"}, inplace=False,
     ... )
-
-    The most abundant member of each group survives, ordered by
-    descending identifier:
-
     >>> out.var_names.tolist()
     ['LMNPQ', 'HIKLM', 'ACDEF']
+    >>> out.var["peptide_ids"].tolist()
+    ['LMNPQ', 'EFGHI;HIKLM', 'ACDEF;CDE']
     >>> out.X
     array([[40., 99., 30.]])
 
-    Every member is recorded, including the ones that lost:
-
-    >>> out.var["peptide_ids"].tolist()
-    ['LMNPQ', 'EFGHI;HIKLM', 'ACDEF;CDE']
-    >>> out.var["n_grouped"].tolist()
-    [1, 2, 2]
-
-    ``ACDEF`` and ``EFGHI`` overlap in the protein while neither
-    contains the other, which is what substring containment misses; and
-    ``CDE`` is grouped with the container it sits strictly inside.
-
-    >>> out.var[["peptide_start", "peptide_end"]].values
-    array([[10., 14.],
-           [ 7., 11.],
-           [ 1.,  5.]])
+    References
+    ----------
+    .. [1] Hafen R and Bludau I. CCprofiler, version 0.99.1, branch
+       ``proteoformLocationMapping`` at git ref ``31a3043``; files
+       ``R/summarizeRedundantPeptides.R`` and
+       ``R/proteinQuantification.R``. Note this is a branch and not a
+       release tag: these functions are absent from ``v1.0.1-copf``.
+       https://github.com/CCprofiler/CCprofiler/tree/proteoformLocationMapping
     """
     # -- validate everything before doing any work
     _validate_arguments(

--- a/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
+++ b/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
@@ -3,27 +3,115 @@
 Reimplementation of CCprofiler's
 ``summarizeAlternativePeptideSequences(topN = 1)`` together with the
 ``proteinQuantification(topN, keep_less)`` selection it delegates to.
-Reference source: CCprofiler at git ref ``31a3043`` (branch
-``proteoformLocationMapping``), files ``R/summarizeRedundantPeptides.R``
-and ``R/proteinQuantification.R``.
 
-The algorithm has three layers, and the terms are used consistently
-throughout this module:
+Reference source
+    https://github.com/CCprofiler/CCprofiler/tree/proteoformLocationMapping
 
-**neighbourhood**
-    ``coPeps(x)`` -- the peptides ``q`` of the same protein whose start
-    OR end position falls inside ``x``'s interval.
-**label**
-    the union of every neighbourhood that contains ``x``.
-**group**
-    all peptides carrying an identical label. Exactly one row survives
-    per group.
+    Branch ``proteoformLocationMapping``, git ref ``31a3043``, files
+    ``R/summarizeRedundantPeptides.R`` and ``R/proteinQuantification.R``.
+    Note this is a branch, not a release tag: the functions below are
+    absent from ``v1.0.1-copf``.
 
-This is not the same grouping as
-:func:`~proteopy.pp.summarize_overlapping_peptides`, which uses
-substring containment and aggregates. Here peptides are grouped by
-their positions in the protein sequence, and the most abundant member
-is *selected* while the rest are discarded.
+Algorithm
+---------
+Peptides are handled one protein at a time. Let ``P`` be the peptides
+of a protein. Each ``x`` in ``P`` carries a closed, 1-based interval
+``[s(x), e(x)]`` locating where its modification-stripped sequence
+first occurs in the protein sequence, or ``UNDEF`` when the sequence
+cannot be located there at all.
+
+**Membership.** The neighbourhood of ``x`` is every peptide whose start
+or end falls inside ``x``'s interval::
+
+    N(x) = { q in P : s(q) in [s(x), e(x)]  or  e(q) in [s(x), e(x)] }
+
+Every comparison involving ``UNDEF`` is false, so an unlocated peptide
+belongs to no neighbourhood and its own neighbourhood is empty.
+
+``N`` is deliberately **not symmetric**. If ``q`` lies strictly inside
+``x`` then ``q`` is in ``N(x)`` but ``x`` is not in ``N(q)``, because
+the test only asks where the *other* peptide's endpoints land.
+
+**Label.** The label of ``x`` is the union of every neighbourhood that
+contains it — a one-hop union, *not* a transitive closure::
+
+    L(x) = union of { N(y) : y in P and x in N(y) }
+
+**Group.** Peptides carrying the same label form a group::
+
+    G(x) = { q in P : L(q) = L(x) }
+
+**Selection.** With ``T(x)`` the total intensity of ``x`` summed over
+all samples, propagating missing values, the members of a group are
+ordered by::
+
+    key(x) = ( T(x) is missing,  -T(x),  tie_break_key(id(x)) )
+
+Complete peptides come first, then descending abundance, then a
+deterministic tie-break on the identifier. The leading ``top_n``
+members are kept and the rest discarded, so exactly one row survives
+per group.
+
+Worked example
+--------------
+Protein ``ACDEFGHIKLMNPQRSTVWY`` with five peptides: a chain of four in
+which only adjacent pairs overlap, plus ``CDE`` lying strictly inside
+``ACDEF``::
+
+    ACDEF [1, 5]   EFGHI [4, 8]   HIKLM [7, 11]   LMNPQ [10, 14]
+    CDE   [2, 4]
+
+    N(ACDEF) = {ACDEF, CDE, EFGHI}
+    N(CDE)   = {CDE, EFGHI}                 <- ACDEF absent: N is asymmetric
+    N(EFGHI) = {ACDEF, CDE, EFGHI, HIKLM}
+    N(HIKLM) = {EFGHI, HIKLM, LMNPQ}
+    N(LMNPQ) = {HIKLM, LMNPQ}
+
+    L(ACDEF) = L(CDE)   = {ACDEF, CDE, EFGHI, HIKLM}
+    L(EFGHI) = L(HIKLM) = {ACDEF, CDE, EFGHI, HIKLM, LMNPQ}
+    L(LMNPQ)            = {EFGHI, HIKLM, LMNPQ}
+
+    G1 = {ACDEF, CDE}    G2 = {EFGHI, HIKLM}    G3 = {LMNPQ}
+
+Three groups, so three peptides survive. Two properties are visible
+here and both are load-bearing:
+
+* ``CDE`` groups with the container it sits inside, even though the
+  membership relation between them runs one way only.
+* A transitive closure over the same overlaps would merge all five into
+  a single group and keep ONE peptide. The chain's two interior members
+  are what separate the rules: each sits in three neighbourhoods, so
+  each absorbs the whole set, while the two ends do not.
+
+Missing values
+--------------
+A peptide with any missing sample has ``T(x)`` missing and sorts LAST,
+so any complete competitor beats it however small its observed values
+are. This is deprioritisation, not removal:
+
+* With a complete member present, that member wins and the incomplete
+  one is discarded like any other loser.
+* When **every** member is missing, all totals are missing, nothing
+  separates them on abundance, and ``tie_break_key`` alone decides. The
+  winner passes through with its missing values intact, for a later
+  completeness filter to act on.
+* At ``top_n = 1`` no arithmetic happens — the surviving row is copied
+  verbatim — so a missing value can be neither created nor spread.
+* At ``top_n > 1`` the selected rows are summed and missingness
+  **propagates**: a sample missing in any contributor is missing in the
+  result, and a group whose members are all missing sums to missing.
+
+Relationship to summarize_overlapping_peptides
+----------------------------------------------
+A different grouping and a different reduction.
+:func:`~proteopy.pp.summarize_overlapping_peptides` groups by substring
+containment and *aggregates* the members; this function groups by
+position in the protein sequence and *selects* among them. Positional
+overlap also sees pairs that containment cannot — ``ACDEF`` and
+``EFGHI`` above overlap in the protein while neither contains the
+other — and it needs no separate modification-summarisation step,
+because two peptidoforms of one stripped sequence share an interval and
+therefore a group.
 """
 
 import re
@@ -34,13 +122,12 @@ from collections.abc import Callable, Iterable
 import anndata as ad
 import numpy as np
 import pandas as pd
-from scipy import sparse
 
 from proteopy.pp.quantification import (
     _aggregate_var_value,
     _rebuild_adata,
 )
-from proteopy.utils.anndata import check_proteodata
+from proteopy.utils.anndata import check_proteodata, is_proteodata
 
 # IUPAC one-letter codes. Broader than the canonical twenty on purpose:
 # UniProt sequences legitimately contain U (selenocysteine) and the
@@ -164,6 +251,18 @@ def _validate_var(
     for col in keep_var_cols or ():
         if col not in adata.var.columns:
             raise KeyError(f"'{col}' not found in adata.var")
+
+    # Nothing to classify when there are no peptides; `is_proteodata`
+    # reports such an object as level-less, which would be a confusing
+    # error for what is a legitimate (if degenerate) input.
+    _, level = is_proteodata(adata) if adata.n_vars else (True, "peptide")
+    if level != "peptide":
+        raise ValueError(
+            "summarize_peptides_by_neighbourhood_union requires "
+            "peptide-level proteodata: .var must hold 'peptide_id' "
+            "matching .var_names and 'protein_id', with each peptide "
+            f"mapping to exactly one protein. Detected level: {level!r}."
+        )
 
     clashes = [c for c in written_cols if c in adata.var.columns]
     if clashes:
@@ -571,7 +670,8 @@ def summarize_peptides_by_neighbourhood_union(
         annotations are dropped: the surviving row's metadata is one
         member's, not the group's, and carrying it would invite it to
         be read as representative. Layers are dropped for the same
-        reason.
+        reason. ``.X`` is always dense, including when the input was
+        sparse.
 
     Raises
     ------
@@ -584,30 +684,53 @@ def summarize_peptides_by_neighbourhood_union(
 
     Examples
     --------
-    Positional overlap groups peptides that substring containment
-    cannot see: ``ABCDEF`` and ``DEFGHI`` overlap in the protein but
-    neither contains the other.
+    The worked example from the module docstring: a chain of four
+    overlapping peptides, plus ``CDE`` lying strictly inside ``ACDEF``.
+    It yields three groups — ``{ACDEF, CDE}``, ``{EFGHI, HIKLM}`` and
+    ``{LMNPQ}`` — so three of the five peptides survive.
 
     >>> import numpy as np
     >>> import pandas as pd
     >>> from anndata import AnnData
     >>> import proteopy as pr
-    >>> pids = ["ABCDEF", "DEFGHI"]
+    >>> pids = ["ACDEF", "CDE", "EFGHI", "HIKLM", "LMNPQ"]
     >>> var = pd.DataFrame(
-    ...     {"peptide_id": pids, "protein_id": ["P1", "P1"]},
+    ...     {"peptide_id": pids, "protein_id": ["P1"] * 5},
     ...     index=pids,
     ... )
     >>> obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
     >>> adata = AnnData(
-    ...     X=np.array([[10.0, 99.0]]), obs=obs, var=var,
+    ...     X=np.array([[30.0, 5.0, 20.0, 99.0, 40.0]]),
+    ...     obs=obs,
+    ...     var=var,
     ... )
     >>> out = pr.pp.summarize_peptides_by_neighbourhood_union(
-    ...     adata, {"P1": "ABCDEFGHI"}, inplace=False,
+    ...     adata, {"P1": "ACDEFGHIKLMNPQRSTVWY"}, inplace=False,
     ... )
+
+    The most abundant member of each group survives, ordered by
+    descending identifier:
+
     >>> out.var_names.tolist()
-    ['DEFGHI']
+    ['LMNPQ', 'HIKLM', 'ACDEF']
     >>> out.X
-    array([[99.]])
+    array([[40., 99., 30.]])
+
+    Every member is recorded, including the ones that lost:
+
+    >>> out.var["peptide_ids"].tolist()
+    ['LMNPQ', 'EFGHI;HIKLM', 'ACDEF;CDE']
+    >>> out.var["n_grouped"].tolist()
+    [1, 2, 2]
+
+    ``ACDEF`` and ``EFGHI`` overlap in the protein while neither
+    contains the other, which is what substring containment misses; and
+    ``CDE`` is grouped with the container it sits strictly inside.
+
+    >>> out.var[["peptide_start", "peptide_end"]].values
+    array([[10., 14.],
+           [ 7., 11.],
+           [ 1.,  5.]])
     """
     # -- validate everything before doing any work
     _validate_arguments(
@@ -642,8 +765,12 @@ def summarize_peptides_by_neighbourhood_union(
     )
 
     # -- matrix, densified; only .X is read
-    was_sparse = sparse.issparse(adata.X)
-    X = adata.X.toarray() if was_sparse else np.asarray(adata.X)
+    X = adata.X
+    # Densified unconditionally: the algorithm ranks and reorders whole
+    # columns and gains nothing from sparsity, and a matrix of peptide
+    # intensities is not meaningfully sparse -- an absent measurement is
+    # missing, not zero.
+    X = X.toarray() if hasattr(X, "toarray") else np.asarray(X)
     X = X.astype(float, copy=True)
     if zero_to_na:
         X[X == 0] = np.nan
@@ -740,9 +867,6 @@ def summarize_peptides_by_neighbourhood_union(
             f"{adata.n_vars} -> {var_new.shape[0]} peptides across "
             f"{len(selections)} neighbourhood group(s)"
         )
-
-    if was_sparse:
-        X_new = sparse.csr_matrix(X_new)
 
     result = _rebuild_adata(adata, X_new, var_new, inplace)
     check_proteodata(adata if inplace else result)

--- a/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
+++ b/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
@@ -36,7 +36,10 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
-from proteopy.pp.quantification import _rebuild_adata
+from proteopy.pp.quantification import (
+    _aggregate_var_value,
+    _rebuild_adata,
+)
 from proteopy.utils.anndata import check_proteodata
 
 # IUPAC one-letter codes. Broader than the canonical twenty on purpose:
@@ -138,9 +141,27 @@ def _validate_arguments(
         raise ValueError("`zero_to_na` and `fill_na` are mutually exclusive.")
 
 
-def _validate_var(adata, peptide_col, protein_col, written_cols):
+def _validate_var(
+    adata, peptide_col, protein_col, written_cols, keep_var_cols
+):
     """Check the required columns exist and the written ones do not."""
     for col in (peptide_col, protein_col):
+        if col not in adata.var.columns:
+            raise KeyError(f"'{col}' not found in adata.var")
+
+    # Reserved before existent: a reserved name is a contract error
+    # whether or not the caller happens to have such a column.
+    reserved = [
+        c
+        for c in (keep_var_cols or ())
+        if c in (peptide_col, protein_col, *written_cols)
+    ]
+    if reserved:
+        raise ValueError(
+            "keep_var_cols must not name a column this function "
+            f"already writes: {', '.join(repr(c) for c in reserved)}."
+        )
+    for col in keep_var_cols or ():
         if col not in adata.var.columns:
             raise KeyError(f"'{col}' not found in adata.var")
 
@@ -450,6 +471,7 @@ def summarize_peptides_by_neighbourhood_union(
     fill_na: float | int | None = None,
     sort_descending_id: bool = True,
     key_added: str = "peptide_ids",
+    keep_var_cols: list[str] | None = None,
     inplace: bool = True,
     verbose: bool = False,
 ) -> ad.AnnData | None:
@@ -544,11 +566,12 @@ def summarize_peptides_by_neighbourhood_union(
         The summarised object when ``inplace=False``, otherwise None.
 
         ``.var`` is reduced to ``peptide_id``, ``protein_id``,
-        ``peptide_start``, ``peptide_end``, ``key_added`` and
-        ``n_grouped``. Other annotations are dropped: the surviving
-        row's metadata is one member's, not the group's, and carrying
-        it would invite it to be read as representative. Layers are
-        dropped for the same reason.
+        ``peptide_start``, ``peptide_end``, ``key_added``,
+        ``n_grouped`` and anything named in ``keep_var_cols``. Other
+        annotations are dropped: the surviving row's metadata is one
+        member's, not the group's, and carrying it would invite it to
+        be read as representative. Layers are dropped for the same
+        reason.
 
     Raises
     ------
@@ -598,7 +621,7 @@ def summarize_peptides_by_neighbourhood_union(
         fill_na,
     )
     written = (_START_COL, _END_COL, key_added, _N_COL)
-    _validate_var(adata, peptide_col, protein_col, written)
+    _validate_var(adata, peptide_col, protein_col, written, keep_var_cols)
     check_proteodata(adata)
 
     sequences = _resolve_annotator(annotator)
@@ -632,6 +655,9 @@ def summarize_peptides_by_neighbourhood_union(
     X = X[:, kept]
     peptides, proteins = peptides[kept], proteins[kept]
     starts, ends = starts[kept], ends[kept]
+    # Positionally aligned with the arrays above, so group member
+    # indices address it directly.
+    source_var = adata.var.iloc[kept]
 
     # A plain sum, so NaN propagates -- an incomplete peptide gets a NaN
     # total and ranks last.
@@ -674,6 +700,13 @@ def summarize_peptides_by_neighbourhood_union(
                 _N_COL: len(sel["members"]),
             }
         )
+        for col in keep_var_cols or ():
+            # Aggregated over every member, not taken from the
+            # survivor: the point of dropping annotations is that one
+            # member's value is not the group's.
+            records[-1][col] = _aggregate_var_value(
+                source_var[col].iloc[sel["members"]]
+            )
 
     if columns:
         X_new = np.column_stack(columns)
@@ -689,6 +722,7 @@ def summarize_peptides_by_neighbourhood_union(
             _END_COL,
             key_added,
             _N_COL,
+            *(keep_var_cols or ()),
         ],
     )
     var_new[_START_COL] = var_new[_START_COL].astype(float)

--- a/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
+++ b/proteopy/pp/summarize_peptides_by_neighbourhood_union.py
@@ -543,8 +543,10 @@ def summarize_peptides_by_neighbourhood_union(
         silence is the reference's real blind spot.
     tie_break_key : callable, optional
         Key applied to the peptide identifier to resolve equal totals.
-        Defaults to :func:`letters_first_key`, which places ``(`` and
-        ``[`` after the letters so an unmodified identifier wins.
+        Defaults to an ordering that places non-letters after
+        letters, so ``(`` and ``[`` both sort after ``Z`` and an
+        unmodified identifier wins a tie against any annotated form
+        of itself.
     zero_to_na : bool, optional
         If True, treat zeros as missing before ranking.
     fill_na : float | int | None, optional

--- a/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
+++ b/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
@@ -101,11 +101,19 @@ def write_fasta(tmp_path, text, name="dummy.fasta"):
     return str(path)
 
 
-# -- FASTA handling ---------------------------------------------------
+class TestSummarizePeptidesByNeighbourhoodUnion:
+    """CCprofiler-equivalent peptide summarisation.
 
+    One class per function under test. The topic groupings that
+    were previously separate classes are retained below as header
+    comments, each naming the class it replaced.
+    """
 
-class TestFasta:
-    """Header parsing replicates CCprofiler's ``gsub``."""
+    # -- FASTA handling ---------------------------------------------------
+
+    # (was class TestFasta)
+    #
+    # Header parsing replicates CCprofiler's ``gsub``.
 
     def test_accession_is_extracted_between_pipes(self, tmp_path):
         path = write_fasta(
@@ -160,13 +168,12 @@ class TestFasta:
         assert survivors(from_path) == survivors(from_dict)
         np.testing.assert_array_equal(from_path.X, from_dict.X)
 
+    # -- Position annotation ----------------------------------------------
 
-# -- Position annotation ----------------------------------------------
-
-
-class TestPositions:
-    """Positions match ``seqinr::words.pos(...)[1]``: first occurrence,
-    1-based, inclusive."""
+    # (was class TestPositions)
+    #
+    # Positions match ``seqinr::words.pos(...)[1]``: first occurrence,
+    # 1-based, inclusive.
 
     def test_positions_are_first_occurrence_one_based(self):
         adata = make_adata(
@@ -240,27 +247,26 @@ class TestPositions:
         out = summarize(adata, _FASTA, inplace=False)
         assert out.var_names.tolist() == ["AC(UniMod:4)DEF"]
 
+    # -- The stripped sequence must be an amino-acid sequence -------------
 
-# -- The stripped sequence must be an amino-acid sequence -------------
-
-
-class TestStrippedSequenceAlphabet:
-    """After ``mod_regex`` is applied, what remains must be a pure
-    amino-acid sequence. Anything else is a malformed identifier.
-
-    This is what makes ``mod_regex`` self-checking: the caller declares
-    what to disregard, and the alphabet check verifies the declaration
-    was complete. No notation-specific pattern has to be hard-coded to
-    detect mass shifts, bracket tags, lowercase markers or anything
-    else -- none of them are amino-acid letters.
-
-    It is a hard error under every policy. An identifier carrying
-    residual notation is a configuration mistake, not a property of the
-    data, so neither ``on_unlocated_peptide`` nor ``on_unknown_protein``
-    suppresses it. Letting it through would give the peptide NaN
-    positions and drop it silently into the empty-label group, which is
-    exactly the behaviour this check exists to prevent.
-    """
+    # (was class TestStrippedSequenceAlphabet)
+    #
+    # After ``mod_regex`` is applied, what remains must be a pure
+    # amino-acid sequence. Anything else is a malformed identifier.
+    #
+    # This is what makes ``mod_regex`` self-checking: the caller declares
+    # what to disregard, and the alphabet check verifies the declaration
+    # was complete. No notation-specific pattern has to be hard-coded to
+    # detect mass shifts, bracket tags, lowercase markers or anything
+    # else -- none of them are amino-acid letters.
+    #
+    # It is a hard error under every policy. An identifier carrying
+    # residual notation is a configuration mistake, not a property of the
+    # data, so neither ``on_unlocated_peptide`` nor ``on_unknown_protein``
+    # suppresses it. Letting it through would give the peptide NaN
+    # positions and drop it silently into the empty-label group, which is
+    # exactly the behaviour this check exists to prevent.
+    #
 
     def test_residual_mass_shift_raises(self):
         adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
@@ -374,29 +380,28 @@ class TestStrippedSequenceAlphabet:
         )
         assert survivors(out) == {"ACDEF"}
 
+    # -- Proteins missing from the annotator ------------------------------
 
-# -- Proteins missing from the annotator ------------------------------
-
-
-class TestUnknownProtein:
-    """A protein absent from the annotator, governed by
-    ``on_unknown_protein: {'raise', 'skip', 'keep'}``.
-
-    ``'raise'`` is the default: a protein missing from the FASTA is
-    usually a mismatched-input error worth stopping for, and the
-    reference is only half-vocal about it (it prints the accession and
-    carries on).
-
-    ``'keep'`` reproduces the reference exactly -- every peptide of the
-    protein gets a NaN position, so they share the empty label, collapse
-    into one group, and the single survivor is then removed downstream
-    by the >=2-peptide filter.
-
-    ``'skip'`` discards those peptides upfront. Measured equivalent on
-    the reference dataset (5 proteins, 23 peptides, identical
-    24,534-peptide result) but NOT equivalent in general, which
-    ``test_keep_and_skip_differ_for_a_one_peptide_protein`` pins.
-    """
+    # (was class TestUnknownProtein)
+    #
+    # A protein absent from the annotator, governed by
+    # ``on_unknown_protein: {'raise', 'skip', 'keep'}``.
+    #
+    # ``'raise'`` is the default: a protein missing from the FASTA is
+    # usually a mismatched-input error worth stopping for, and the
+    # reference is only half-vocal about it (it prints the accession and
+    # carries on).
+    #
+    # ``'keep'`` reproduces the reference exactly -- every peptide of the
+    # protein gets a NaN position, so they share the empty label, collapse
+    # into one group, and the single survivor is then removed downstream
+    # by the >=2-peptide filter.
+    #
+    # ``'skip'`` discards those peptides upfront. Measured equivalent on
+    # the reference dataset (5 proteins, 23 peptides, identical
+    # 24,534-peptide result) but NOT equivalent in general, which
+    # ``test_keep_and_skip_differ_for_a_one_peptide_protein`` pins.
+    #
 
     def test_absent_protein_raises_by_default(self):
         adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
@@ -414,7 +419,7 @@ class TestUnknownProtein:
         assert "GHOST_A" in str(excinfo.value)
         assert "GHOST_B" in str(excinfo.value)
 
-    def test_error_names_the_available_modes(self):
+    def test_unknown_protein_error_names_the_available_modes(self):
         adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
         with pytest.raises(ValueError, match="skip"):
             summarize(adata, _FASTA, inplace=False)
@@ -550,19 +555,18 @@ class TestUnknownProtein:
                 inplace=False,
             )
 
+    # -- Peptides not found in their protein sequence ---------------------
 
-# -- Peptides not found in their protein sequence ---------------------
-
-
-class TestUnlocatedPeptides:
-    """A peptide whose sequence does not occur in its protein.
-
-    The reference is silent about this case -- ``words.pos(...)[1]``
-    yields NA and the peptide continues as one that overlaps nothing.
-    ``'raise'`` is the default because that silence is the reference's
-    real blind spot; ``'keep'`` reproduces it exactly and is what the
-    COPF pipeline passes.
-    """
+    # (was class TestUnlocatedPeptides)
+    #
+    # A peptide whose sequence does not occur in its protein.
+    #
+    # The reference is silent about this case -- ``words.pos(...)[1]``
+    # yields NA and the peptide continues as one that overlaps nothing.
+    # ``'raise'`` is the default because that silence is the reference's
+    # real blind spot; ``'keep'`` reproduces it exactly and is what the
+    # COPF pipeline passes.
+    #
 
     def test_unlocated_peptide_raises_by_default(self):
         adata = make_adata(["WWWWW"], ["P1"], [[1.0]])
@@ -574,7 +578,7 @@ class TestUnlocatedPeptides:
         with pytest.raises(ValueError, match="P1"):
             summarize(adata, _FASTA, inplace=False)
 
-    def test_error_names_the_available_modes(self):
+    def test_unlocated_peptide_error_names_the_available_modes(self):
         adata = make_adata(["WWWWW"], ["P1"], [[1.0]])
         with pytest.raises(ValueError, match="skip"):
             summarize(adata, _FASTA, inplace=False)
@@ -717,12 +721,11 @@ class TestUnlocatedPeptides:
                 inplace=False,
             )
 
+    # -- Grouping semantics -----------------------------------------------
 
-# -- Grouping semantics -----------------------------------------------
-
-
-class TestGrouping:
-    """The three fidelity-critical properties of the grouping rule."""
+    # (was class TestGrouping)
+    #
+    # The three fidelity-critical properties of the grouping rule.
 
     def test_strictly_contained_peptide_groups_with_its_container(
         self,
@@ -862,13 +865,12 @@ class TestGrouping:
         out = summarize(adata, _FASTA, inplace=False)
         assert survivors(out) == {"AC(UniMod:4)DEF"}
 
+    # -- Selection --------------------------------------------------------
 
-# -- Selection --------------------------------------------------------
-
-
-class TestSelection:
-    """``topN = 1`` SELECTS the most abundant member; it does not
-    aggregate."""
+    # (was class TestSelection)
+    #
+    # ``topN = 1`` SELECTS the most abundant member; it does not
+    # aggregate.
 
     def test_most_abundant_is_selected_not_summed(self):
         """Totals across samples: ACDEF = 1 + 2 = 3,
@@ -893,27 +895,26 @@ class TestSelection:
         out = summarize(adata, _FASTA, inplace=False)
         assert survivors(out) == {"ACDEF"}
 
+    # -- Tie breaking -----------------------------------------------------
 
-# -- Tie breaking -----------------------------------------------------
-
-
-class TestTieBreaking:
-    """Equal totals are resolved by ``tie_break_key``, never by input
-    order.
-
-    CCprofiler uses ``ties.method = "first"``, i.e. whichever row
-    happened to come first, which makes the output depend on how the
-    input table was sorted. A deterministic key removes that
-    dependency.
-
-    Measured on the reference dataset: of 26,473 groups, 4,752 have
-    more than one member and only 7 have a tied winner -- 6 of them
-    ties between two incomplete peptides, 1 a genuine equal-total tie.
-    Switching from row order to the default key changes the pick in 4
-    of the 7, and none of those 4 peptides reaches the reference's
-    24,534-peptide set, so the change costs nothing here. That margin
-    is dataset-specific; re-measure on new data.
-    """
+    # (was class TestTieBreaking)
+    #
+    # Equal totals are resolved by ``tie_break_key``, never by input
+    # order.
+    #
+    # CCprofiler uses ``ties.method = "first"``, i.e. whichever row
+    # happened to come first, which makes the output depend on how the
+    # input table was sorted. A deterministic key removes that
+    # dependency.
+    #
+    # Measured on the reference dataset: of 26,473 groups, 4,752 have
+    # more than one member and only 7 have a tied winner -- 6 of them
+    # ties between two incomplete peptides, 1 a genuine equal-total tie.
+    # Switching from row order to the default key changes the pick in 4
+    # of the 7, and none of those 4 peptides reaches the reference's
+    # 24,534-peptide set, so the change costs nothing here. That margin
+    # is dataset-specific; re-measure on new data.
+    #
 
     def test_ties_are_broken_by_the_ordering_key(self):
         """The default key sorts letters before any non-letter, so the
@@ -998,19 +999,18 @@ class TestTieBreaking:
         out = summarize(adata, _FASTA, inplace=False)
         assert survivors(out) == {"AC(UniMod:4)DEF"}
 
+    # -- Output .var columns ----------------------------------------------
 
-# -- Output .var columns ----------------------------------------------
-
-
-class TestVarColumns:
-    """The surviving row's annotations are NOT representative of its
-    group, so they are not carried over.
-
-    Only two kinds of column survive: those a peptide-level proteodata
-    object requires, and those this function computes. Everything else
-    is dropped, because keeping it would invite the reader to treat one
-    member's metadata as the whole group's.
-    """
+    # (was class TestVarColumns)
+    #
+    # The surviving row's annotations are NOT representative of its
+    # group, so they are not carried over.
+    #
+    # Only two kinds of column survive: those a peptide-level proteodata
+    # object requires, and those this function computes. Everything else
+    # is dropped, because keeping it would invite the reader to treat one
+    # member's metadata as the whole group's.
+    #
 
     def test_var_holds_exactly_the_expected_columns(self):
         adata = make_adata(
@@ -1074,14 +1074,13 @@ class TestVarColumns:
             "n_grouped",
         }
 
+    # -- Identifier naming ------------------------------------------------
 
-# -- Identifier naming ------------------------------------------------
-
-
-class TestNaming:
-    """``id_from`` selects how the surviving row is identified. Only
-    ``'top_ranked'`` is implemented; the parameter exists so that other
-    schemes can be added without a signature change."""
+    # (was class TestNaming)
+    #
+    # ``id_from`` selects how the surviving row is identified. Only
+    # ``'top_ranked'`` is implemented; the parameter exists so that other
+    # schemes can be added without a signature change.
 
     def test_default_names_the_row_after_the_top_ranked_member(self):
         adata = make_adata(
@@ -1118,11 +1117,9 @@ class TestNaming:
         with pytest.raises(ValueError, match="top_ranked"):
             summarize(adata, _FASTA, id_from="longest", inplace=False)
 
+    # -- Provenance -------------------------------------------------------
 
-# -- Provenance -------------------------------------------------------
-
-
-class TestProvenance:
+    # (was class TestProvenance)
 
     def test_peptide_ids_lists_all_group_members_sorted(self):
         adata = make_adata(
@@ -1180,14 +1177,13 @@ class TestProvenance:
         assert "ACDEF" in out.var["peptide_ids"].iloc[0]
         assert "ACDEF" not in survivors(out)
 
+    # -- Guards against silently overwriting .var -------------------------
 
-# -- Guards against silently overwriting .var -------------------------
-
-
-class TestColumnGuards:
-    """Every column the function writes must be absent from the input
-    ``.var``, so a second call or a pre-existing annotation can never
-    be overwritten without the user noticing."""
+    # (was class TestColumnGuards)
+    #
+    # Every column the function writes must be absent from the input
+    # ``.var``, so a second call or a pre-existing annotation can never
+    # be overwritten without the user noticing.
 
     def test_existing_peptide_start_raises(self):
         adata = make_adata(
@@ -1284,23 +1280,22 @@ class TestColumnGuards:
         with pytest.raises(ValueError, match="drop"):
             summarize(adata, _FASTA, inplace=False)
 
+    # -- Missing-value policy ---------------------------------------------
 
-# -- Missing-value policy ---------------------------------------------
-
-
-class TestMissingValues:
-    """Missing values are handled exactly as CCprofiler handles them,
-    with no parameter to choose otherwise.
-
-    ``proteinQuantification`` sums with ``na.rm = FALSE`` and ranks with
-    ``rank()``'s default ``na.last = TRUE``, so a peptide with any
-    missing sample has a ``NaN`` total and ranks LAST.
-
-    That is deprioritisation, not removal. A NaN-bearing peptide with no
-    complete competitor still wins its group and is passed through
-    untouched. The reference depends on this: its zero-variance step is
-    what finally removes such peptides, via ``var()`` propagating ``NA``.
-    """
+    # (was class TestMissingValues)
+    #
+    # Missing values are handled exactly as CCprofiler handles them,
+    # with no parameter to choose otherwise.
+    #
+    # ``proteinQuantification`` sums with ``na.rm = FALSE`` and ranks with
+    # ``rank()``'s default ``na.last = TRUE``, so a peptide with any
+    # missing sample has a ``NaN`` total and ranks LAST.
+    #
+    # That is deprioritisation, not removal. A NaN-bearing peptide with no
+    # complete competitor still wins its group and is passed through
+    # untouched. The reference depends on this: its zero-variance step is
+    # what finally removes such peptides, via ``var()`` propagating ``NA``.
+    #
 
     def test_nan_input_is_accepted(self):
         adata = make_adata(
@@ -1428,11 +1423,9 @@ class TestMissingValues:
         out = summarize(adata, _FASTA, inplace=False)
         assert not np.isnan(out.X).any()
 
+    # -- top_n and keep_less ----------------------------------------------
 
-# -- top_n and keep_less ----------------------------------------------
-
-
-class TestTopNAndKeepLess:
+    # (was class TestTopNAndKeepLess)
 
     def test_top_n_two_sums_the_two_most_abundant(self):
         """Group members total 30 and 10; their sum is 40 per sample."""
@@ -1568,14 +1561,13 @@ class TestTopNAndKeepLess:
         with pytest.raises(ValueError, match="top_n"):
             summarize(adata, _FASTA, top_n=0, inplace=False)
 
+    # -- Output ordering --------------------------------------------------
 
-# -- Output ordering --------------------------------------------------
-
-
-class TestOrdering:
-    """Row order is load-bearing: average-linkage clustering downstream
-    breaks ties by row order, so the reference's closing
-    ``setorder(traces, -id)`` must be reproducible."""
+    # (was class TestOrdering)
+    #
+    # Row order is load-bearing: average-linkage clustering downstream
+    # breaks ties by row order, so the reference's closing
+    # ``setorder(traces, -id)`` must be reproducible.
 
     def test_output_is_ordered_by_descending_identifier(self):
         adata = make_adata(
@@ -1610,11 +1602,9 @@ class TestOrdering:
         values = dict(zip(out.var_names, out.X[0]))
         assert values == {"ACDEF": 1.0, "RSTVWY": 2.0, "LMNPQ": 3.0}
 
+    # -- API contract -----------------------------------------------------
 
-# -- API contract -----------------------------------------------------
-
-
-class TestContract:
+    # (was class TestContract)
 
     def test_inplace_returns_none_and_mutates(self):
         adata = make_adata(

--- a/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
+++ b/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
@@ -1,0 +1,1740 @@
+"""Tests for ``pr.pp.summarize_peptides_by_neighbourhood_union``.
+
+The function reimplements CCprofiler's
+``summarizeAlternativePeptideSequences(topN = 1)`` together with the
+``proteinQuantification(topN, keep_less)`` selection it delegates to.
+Reference source: CCprofiler at git ref ``31a3043`` (branch
+``proteoformLocationMapping``), files ``R/summarizeRedundantPeptides.R``
+and ``R/proteinQuantification.R``.
+
+Every expected value below is computed BY HAND from a small synthetic
+protein, never by calling the code under test.
+
+Three terms are used throughout, matching the algorithm's three layers:
+
+**neighbourhood**
+    ``coPeps(x)`` -- the peptides ``q`` of the same protein whose start
+    OR end falls inside ``x``'s interval ``[x.start, x.end]``.
+**label**
+    the union of every neighbourhood that contains ``x``, sorted and
+    joined with ``';'``.
+**group**
+    all peptides carrying an identical label. One row survives per
+    group.
+
+Several tests exist specifically because the reference algorithm has
+properties that a reasonable reimplementation would silently "correct"
+into something cleaner and wrong:
+
+* ``test_overlap_chain_yields_three_groups_not_one`` -- an A-B-C-D
+  overlap chain yields THREE groups. Transitive closure would give one,
+  selecting one peptide where the reference selects three.
+* ``test_keep_collapses_several_unlocated_peptides_of_one_protein`` --
+  peptides whose position cannot be resolved share the empty label and
+  collapse into a single group per protein. This is how the reference
+  eliminates proteins that are absent from the FASTA.
+* ``test_keep_leaves_a_lone_unlocated_peptide_untouched`` -- the
+  collapse only bites at two or more. The reference's own output
+  contains exactly one unlocated peptide, ``P35235``'s
+  ``VGQALLQGNTER``, which survives because it is alone.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+from scipy import sparse
+
+from proteopy.pp import (
+    summarize_peptides_by_neighbourhood_union as summarize,
+)
+from proteopy.utils.anndata import check_proteodata
+
+
+# -- Synthetic reference protein --------------------------------------
+#
+# Twenty distinct residues, so every substring occurs exactly once and
+# positions are unambiguous by inspection:
+#
+#     A  C  D  E  F  G  H  I  K  L  M  N  P  Q  R  S  T  V  W  Y
+#     1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+
+_P1 = "ACDEFGHIKLMNPQRSTVWY"
+
+_FASTA = {"P1": _P1, "P2": _P1}
+
+# Selenocysteine is a real UniProt residue -- dataset 01's FASTA carries
+# 33 of them, plus X, B and Z -- so the default alphabet must accept it.
+_SELENO = {"S1": "ACUDEF"}
+
+# Intervals used repeatedly below (1-based, inclusive):
+#     ACDEF   1..5      HIKLM   7..11     RSTVWY  15..20
+#     EFGHI   4..8      LMNPQ  10..14
+
+
+# -- Helpers ----------------------------------------------------------
+
+
+def make_adata(peptides, proteins, X, var_extra=None):
+    """Build a minimal peptide-level AnnData."""
+    X = np.asarray(X, dtype=float)
+    samples = [f"s{i + 1}" for i in range(X.shape[0])]
+    var = pd.DataFrame(
+        {"peptide_id": peptides, "protein_id": proteins},
+        index=peptides,
+    )
+    if var_extra is not None:
+        for key, values in var_extra.items():
+            var[key] = values
+    obs = pd.DataFrame({"sample_id": samples}, index=samples)
+    return AnnData(X=X, obs=obs, var=var)
+
+
+def survivors(adata):
+    """Output peptide identifiers as a set."""
+    return set(adata.var_names.astype(str))
+
+
+def write_fasta(tmp_path, text, name="dummy.fasta"):
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+# -- FASTA handling ---------------------------------------------------
+
+
+class TestFasta:
+    """Header parsing replicates CCprofiler's ``gsub``."""
+
+    def test_accession_is_extracted_between_pipes(self, tmp_path):
+        path = write_fasta(
+            tmp_path,
+            ">sp|P1|SRBS2_MOUSE Sorbin and SH3 domain protein\n"
+            "ACDEFGHIKL\nMNPQRSTVWY\n",
+        )
+        adata = make_adata(["ACDEF"], ["P1"], [[10.0]])
+        out = summarize(adata, path, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+
+    def test_header_without_pipes_is_used_verbatim(self, tmp_path):
+        """``iRT_protein`` has no pipes; the gsub leaves it unchanged."""
+        path = write_fasta(tmp_path, ">iRT_protein\nACDEFGHIKL\n")
+        adata = make_adata(["ACDEF"], ["iRT_protein"], [[10.0]])
+        out = summarize(adata, path, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+
+    def test_duplicate_accession_keeps_the_first(self, tmp_path):
+        """Matches Biostrings' name-based subsetting, which takes [1]."""
+        path = write_fasta(
+            tmp_path,
+            ">sp|P1|A\nACDEFGHIKL\n>sp|P1|B\nYYYYYYYYYY\n",
+        )
+        adata = make_adata(["ACDEF"], ["P1"], [[10.0]])
+        out = summarize(adata, path, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+
+    def test_multiline_sequence_is_concatenated(self, tmp_path):
+        path = write_fasta(
+            tmp_path,
+            ">sp|P1|A\nACDEFGHIKL\nMNPQRSTVWY\n",
+        )
+        adata = make_adata(["LMNPQ"], ["P1"], [[10.0]])
+        out = summarize(adata, path, inplace=False)
+        assert out.var["peptide_start"].tolist() == [10.0]
+
+    def test_path_and_dict_are_equivalent(self, tmp_path):
+        path = write_fasta(tmp_path, f">sp|P1|A\n{_P1}\n")
+        peptides, proteins = ["ACDEF", "RSTVWY"], ["P1", "P1"]
+        X = [[10.0, 20.0]]
+        from_path = summarize(
+            make_adata(peptides, proteins, X),
+            path,
+            inplace=False,
+        )
+        from_dict = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            inplace=False,
+        )
+        assert survivors(from_path) == survivors(from_dict)
+        np.testing.assert_array_equal(from_path.X, from_dict.X)
+
+
+# -- Position annotation ----------------------------------------------
+
+
+class TestPositions:
+    """Positions match ``seqinr::words.pos(...)[1]``: first occurrence,
+    1-based, inclusive."""
+
+    def test_positions_are_first_occurrence_one_based(self):
+        adata = make_adata(
+            ["ACDEF", "LMNPQ", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[1.0, 1.0, 1.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            inplace=False,
+            sort_descending_id=False,
+        )
+        assert out.var["peptide_start"].tolist() == [1.0, 10.0, 15.0]
+        assert out.var["peptide_end"].tolist() == [5.0, 14.0, 20.0]
+
+    def test_repeated_subsequence_takes_the_first_occurrence(self):
+        adata = make_adata(["AC"], ["Q1"], [[1.0]])
+        out = summarize(adata, {"Q1": "ACDACD"}, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+
+    def test_unimod_tags_do_not_shift_positions(self):
+        """The tag is stripped before matching, and the END position is
+        computed from the STRIPPED length."""
+        adata = make_adata(
+            ["AC(UniMod:4)DEF"],
+            ["P1"],
+            [[1.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+        assert out.var["peptide_end"].tolist() == [5.0]
+
+    def test_custom_mod_regex_is_honoured(self):
+        adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
+        out = summarize(
+            adata,
+            _FASTA,
+            mod_regex=r"\[.*?\]",
+            inplace=False,
+        )
+        assert out.var["peptide_start"].tolist() == [1.0]
+        assert out.var["peptide_end"].tolist() == [5.0]
+
+    def test_mod_regex_can_cover_several_notations_at_once(self):
+        """One identifier carrying both notations locates correctly
+        only when the pattern covers both."""
+        adata = make_adata(
+            ["AC(UniMod:4)D[+16]EF"],
+            ["P1"],
+            [[1.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            mod_regex=r"\(UniMod:[0-9]+\)|\[.*?\]",
+            inplace=False,
+        )
+        assert out.var["peptide_start"].tolist() == [1.0]
+        assert out.var["peptide_end"].tolist() == [5.0]
+
+    def test_stripping_does_not_rewrite_the_identifier(self):
+        """The regex governs location only. The surviving peptide keeps
+        its annotations, which is why the reference needs no separate
+        modification-summarisation step."""
+        adata = make_adata(
+            ["AC(UniMod:4)DEF"],
+            ["P1"],
+            [[1.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var_names.tolist() == ["AC(UniMod:4)DEF"]
+
+
+# -- The stripped sequence must be an amino-acid sequence -------------
+
+
+class TestStrippedSequenceAlphabet:
+    """After ``mod_regex`` is applied, what remains must be a pure
+    amino-acid sequence. Anything else is a malformed identifier.
+
+    This is what makes ``mod_regex`` self-checking: the caller declares
+    what to disregard, and the alphabet check verifies the declaration
+    was complete. No notation-specific pattern has to be hard-coded to
+    detect mass shifts, bracket tags, lowercase markers or anything
+    else -- none of them are amino-acid letters.
+
+    It is a hard error under every policy. An identifier carrying
+    residual notation is a configuration mistake, not a property of the
+    data, so neither ``on_unlocated_peptide`` nor ``on_unknown_protein``
+    suppresses it. Letting it through would give the peptide NaN
+    positions and drop it silently into the empty-label group, which is
+    exactly the behaviour this check exists to prevent.
+    """
+
+    def test_residual_mass_shift_raises(self):
+        adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match=r"AC\[\+57\]DEF"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_partial_mod_regex_coverage_raises(self):
+        """Covering one of two notations is not enough."""
+        adata = make_adata(
+            ["AC(UniMod:4)D[+16]EF"],
+            ["P1"],
+            [[1.0]],
+        )
+        with pytest.raises(ValueError):
+            summarize(
+                adata,
+                _FASTA,
+                mod_regex=r"\(UniMod:[0-9]+\)",
+                inplace=False,
+            )
+
+    def test_digits_raise(self):
+        adata = make_adata(["ACDEF2"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="ACDEF2"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_lowercase_modification_marker_raises(self):
+        """Some search engines mark modified residues in lowercase."""
+        adata = make_adata(["ACDEFm"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="ACDEFm"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_error_names_the_offending_characters(self):
+        adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError) as excinfo:
+            summarize(adata, _FASTA, inplace=False)
+        message = str(excinfo.value)
+        assert "[" in message and "+" in message
+
+    def test_all_offending_peptides_are_reported(self):
+        adata = make_adata(
+            ["ACDEF1", "EFGHI2"],
+            ["P1", "P1"],
+            [[1.0, 2.0]],
+        )
+        with pytest.raises(ValueError) as excinfo:
+            summarize(adata, _FASTA, inplace=False)
+        assert "ACDEF1" in str(excinfo.value)
+        assert "EFGHI2" in str(excinfo.value)
+
+    def test_skip_does_not_suppress_the_alphabet_error(self):
+        adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match=r"AC\[\+57\]DEF"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unlocated_peptide="skip",
+                inplace=False,
+            )
+
+    def test_keep_does_not_suppress_the_alphabet_error(self):
+        adata = make_adata(["AC[+57]DEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match=r"AC\[\+57\]DEF"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unlocated_peptide="keep",
+                inplace=False,
+            )
+
+    def test_selenocysteine_is_accepted_by_default(self):
+        """``U`` is a real UniProt residue, not notation. Rejecting it
+        would turn a legitimate selenopeptide into a false error."""
+        adata = make_adata(["ACUDEF"], ["S1"], [[1.0]])
+        out = summarize(adata, _SELENO, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+        assert out.var["peptide_end"].tolist() == [6.0]
+
+    def test_ambiguity_codes_are_accepted_by_default(self):
+        adata = make_adata(["AXBZ"], ["S2"], [[1.0]])
+        out = summarize(adata, {"S2": "AXBZ"}, inplace=False)
+        assert out.var["peptide_start"].tolist() == [1.0]
+
+    def test_alphabet_can_be_narrowed_to_the_canonical_twenty(self):
+        adata = make_adata(["ACUDEF"], ["S1"], [[1.0]])
+        with pytest.raises(ValueError, match="ACUDEF"):
+            summarize(
+                adata,
+                _SELENO,
+                alphabet="ACDEFGHIKLMNPQRSTVWY",
+                inplace=False,
+            )
+
+    def test_a_clean_peptide_that_is_simply_absent_still_reports_as_unlocated(  # noqa: E501
+        self,
+    ):
+        """The two error classes stay distinct: ``WWWWW`` is a valid
+        amino-acid sequence, so it reaches the location step and is
+        reported as unlocated -- which ``'skip'`` and ``'keep'`` can
+        act on."""
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="skip",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF"}
+
+
+# -- Proteins missing from the annotator ------------------------------
+
+
+class TestUnknownProtein:
+    """A protein absent from the annotator, governed by
+    ``on_unknown_protein: {'raise', 'skip', 'keep'}``.
+
+    ``'raise'`` is the default: a protein missing from the FASTA is
+    usually a mismatched-input error worth stopping for, and the
+    reference is only half-vocal about it (it prints the accession and
+    carries on).
+
+    ``'keep'`` reproduces the reference exactly -- every peptide of the
+    protein gets a NaN position, so they share the empty label, collapse
+    into one group, and the single survivor is then removed downstream
+    by the >=2-peptide filter.
+
+    ``'skip'`` discards those peptides upfront. Measured equivalent on
+    the reference dataset (5 proteins, 23 peptides, identical
+    24,534-peptide result) but NOT equivalent in general, which
+    ``test_keep_and_skip_differ_for_a_one_peptide_protein`` pins.
+    """
+
+    def test_absent_protein_raises_by_default(self):
+        adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
+        with pytest.raises(ValueError, match="ABSENT"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_all_missing_proteins_are_reported_not_just_the_first(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["GHOST_A", "GHOST_B"],
+            [[1.0, 2.0]],
+        )
+        with pytest.raises(ValueError) as excinfo:
+            summarize(adata, _FASTA, inplace=False)
+        assert "GHOST_A" in str(excinfo.value)
+        assert "GHOST_B" in str(excinfo.value)
+
+    def test_error_names_the_available_modes(self):
+        adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
+        with pytest.raises(ValueError, match="skip"):
+            summarize(adata, _FASTA, inplace=False)
+        with pytest.raises(ValueError, match="keep"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_skip_discards_the_absent_protein_peptides(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "ABSENT"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unknown_protein="skip",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF"}
+
+    def test_keep_collapses_the_absent_protein_to_one_peptide(self):
+        """All three peptides get NaN positions, share the empty label,
+        and form ONE group. This is the mechanism by which the reference
+        strips a FASTA-absent protein down to a single peptide."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI", "HIKLM"],
+            ["ABSENT", "ABSENT", "ABSENT"],
+            [[10.0, 99.0, 5.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unknown_protein="keep",
+            inplace=False,
+        )
+        assert survivors(out) == {"EFGHI"}
+
+    def test_keep_gives_absent_protein_peptides_nan_positions(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["ABSENT", "ABSENT"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unknown_protein="keep",
+            inplace=False,
+        )
+        assert np.isnan(out.var["peptide_start"]).all()
+
+    def test_keep_and_skip_differ_for_a_one_peptide_protein(self):
+        """The two modes coincide on the reference dataset only because
+        a >=2-peptide filter runs downstream. With a single peptide
+        there is nothing to collapse, so ``'keep'`` lets it through."""
+        peptides, proteins = ["ACDEF", "EFGHI"], ["P1", "ABSENT"]
+        X = [[10.0, 99.0]]
+        kept = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            on_unknown_protein="keep",
+            inplace=False,
+        )
+        skipped = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            on_unknown_protein="skip",
+            inplace=False,
+        )
+        assert survivors(kept) == {"ACDEF", "EFGHI"}
+        assert survivors(skipped) == {"ACDEF"}
+
+    def test_on_unlocated_peptide_skip_does_not_govern_proteins(self):
+        adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
+        with pytest.raises(ValueError, match="ABSENT"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unlocated_peptide="skip",
+                inplace=False,
+            )
+
+    def test_on_unlocated_peptide_keep_does_not_govern_proteins(self):
+        adata = make_adata(["ACDEF"], ["ABSENT"], [[1.0]])
+        with pytest.raises(ValueError, match="ABSENT"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unlocated_peptide="keep",
+                inplace=False,
+            )
+
+    def test_the_two_policies_are_independent(self):
+        """Allowing absent proteins does not silence an unlocated
+        peptide in a protein that IS present."""
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["ABSENT", "P1"],
+            [[10.0, 99.0]],
+        )
+        with pytest.raises(ValueError, match="WWWWW"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unknown_protein="keep",
+                inplace=False,
+            )
+
+    def test_both_policies_together_reproduce_the_reference(self):
+        """The combination the COPF pipeline passes: no pre-filter, no
+        error, and NaN positions for everything unresolvable."""
+        adata = make_adata(
+            ["ACDEF", "WWWWW", "EFGHI"],
+            ["P1", "P1", "ABSENT"],
+            [[10.0, 99.0, 5.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unknown_protein="keep",
+            on_unlocated_peptide="keep",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF", "WWWWW", "EFGHI"}
+
+    def test_invalid_on_unknown_protein_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="on_unknown_protein"):
+            summarize(
+                adata,
+                _FASTA,
+                on_unknown_protein="ignore",
+                inplace=False,
+            )
+
+
+# -- Peptides not found in their protein sequence ---------------------
+
+
+class TestUnlocatedPeptides:
+    """A peptide whose sequence does not occur in its protein.
+
+    The reference is silent about this case -- ``words.pos(...)[1]``
+    yields NA and the peptide continues as one that overlaps nothing.
+    ``'raise'`` is the default because that silence is the reference's
+    real blind spot; ``'keep'`` reproduces it exactly and is what the
+    COPF pipeline passes.
+    """
+
+    def test_unlocated_peptide_raises_by_default(self):
+        adata = make_adata(["WWWWW"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="WWWWW"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_error_names_the_peptide_and_its_protein(self):
+        adata = make_adata(["WWWWW"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="P1"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_error_names_the_available_modes(self):
+        adata = make_adata(["WWWWW"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="skip"):
+            summarize(adata, _FASTA, inplace=False)
+        with pytest.raises(ValueError, match="keep"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_skip_removes_the_peptide_entirely(self):
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="skip",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF"}
+
+    def test_skip_leaves_no_trace_in_the_provenance(self):
+        """Skipped means removed before grouping, so it must not appear
+        as a group member either."""
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="skip",
+            inplace=False,
+        )
+        assert out.var["peptide_ids"].tolist() == ["ACDEF"]
+
+    def test_keep_leaves_a_lone_unlocated_peptide_untouched(self):
+        """The reference's own 24,534-peptide output contains exactly
+        one unlocated peptide -- ``P35235``'s ``VGQALLQGNTER`` -- and it
+        survives precisely because no other peptide of that protein
+        shares its empty label."""
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="keep",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF", "WWWWW"}
+
+    def test_keep_gives_an_unlocated_peptide_nan_positions(self):
+        adata = make_adata(
+            ["ACDEF", "WWWWW"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="keep",
+            inplace=False,
+            sort_descending_id=False,
+        )
+        positions = dict(
+            zip(out.var_names, out.var["peptide_start"]),
+        )
+        assert positions["ACDEF"] == 1.0
+        assert np.isnan(positions["WWWWW"])
+
+    def test_keep_collapses_several_unlocated_peptides_of_one_protein(
+        self,
+    ):
+        """NaN compares False against everything, so these share the
+        empty label and form ONE group -- the mechanism that strips a
+        FASTA-absent protein down to a single peptide."""
+        adata = make_adata(
+            ["WWWWW", "YYYYY", "ACDEF"],
+            ["P1", "P1", "P1"],
+            [[10.0, 99.0, 5.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="keep",
+            inplace=False,
+        )
+        assert survivors(out) == {"YYYYY", "ACDEF"}
+
+    def test_keep_does_not_group_unlocated_peptides_across_proteins(
+        self,
+    ):
+        """The empty label is still scoped to a protein."""
+        adata = make_adata(
+            ["WWWWW", "YYYYY"],
+            ["P1", "P2"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            on_unlocated_peptide="keep",
+            inplace=False,
+        )
+        assert survivors(out) == {"WWWWW", "YYYYY"}
+
+    def test_keep_and_skip_disagree_on_the_peptide_set(self):
+        """Pins that the modes are not interchangeable. Choosing wrong
+        costs exactly one peptide on the reference dataset, which is
+        enough to break set-level agreement."""
+        peptides, proteins = ["ACDEF", "WWWWW"], ["P1", "P1"]
+        X = [[10.0, 99.0]]
+        kept = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            on_unlocated_peptide="keep",
+            inplace=False,
+        )
+        skipped = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            on_unlocated_peptide="skip",
+            inplace=False,
+        )
+        assert survivors(kept) - survivors(skipped) == {"WWWWW"}
+
+    def test_invalid_on_unlocated_peptide_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(
+            ValueError,
+            match="on_unlocated_peptide",
+        ):
+            summarize(
+                adata,
+                _FASTA,
+                on_unlocated_peptide="ignore",
+                inplace=False,
+            )
+
+
+# -- Grouping semantics -----------------------------------------------
+
+
+class TestGrouping:
+    """The three fidelity-critical properties of the grouping rule."""
+
+    def test_strictly_contained_peptide_groups_with_its_container(
+        self,
+    ):
+        """``CDEFGHIKLMNPQRST`` spans 2..17; ``HIKLM`` spans 7..11,
+        strictly inside it.
+
+        Neighbourhoods -- note these are NOT symmetric, because the
+        test only asks whether the OTHER peptide's start or end lands
+        inside the anchor's interval::
+
+            coPeps(LONG)  = {LONG, SHORT}   7 and 11 are inside 2..17
+            coPeps(SHORT) = {SHORT}         2 and 17 are OUTSIDE 7..11
+
+        Labels -- the union of every neighbourhood containing the
+        peptide::
+
+            label(LONG)  = coPeps(LONG)                 = {LONG, SHORT}
+            label(SHORT) = coPeps(LONG) | coPeps(SHORT) = {LONG, SHORT}
+
+        Equal labels, so ONE group with members {LONG, SHORT}, and the
+        more abundant member survives.
+
+        ⚠️ This test does NOT pin the asymmetry, despite it being real
+        in the source. When ``q`` is strictly inside ``x``, every
+        peptide reaching ``q``'s interval also reaches ``x``'s, so
+        ``coPeps(q) ⊆ coPeps(x)`` and the extra symmetric edge adds
+        nothing to any union. Brute-forced over 200,000 random interval
+        sets (87,061 containing a strict containment): zero label
+        differences between the asymmetric and symmetric rules. The
+        asymmetry is therefore unobservable through this API, and
+        pinning it needs a unit test on the private label helper.
+        """
+        adata = make_adata(
+            ["CDEFGHIKLMNPQRST", "HIKLM"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"HIKLM"}
+        assert out.var["peptide_ids"].tolist() == [
+            "CDEFGHIKLMNPQRST;HIKLM",
+        ]
+
+    def test_overlap_chain_yields_three_groups_not_one(self):
+        """An A-B-C-D chain with only adjacent pairs overlapping.
+
+        Intervals: ACDEF 1..5, EFGHI 4..8, HIKLM 7..11, LMNPQ 10..14.
+
+        ``coPeps`` sets::
+
+            coPeps(ACDEF) = {ACDEF, EFGHI}
+            coPeps(EFGHI) = {ACDEF, EFGHI, HIKLM}
+            coPeps(HIKLM) = {EFGHI, HIKLM, LMNPQ}
+            coPeps(LMNPQ) = {HIKLM, LMNPQ}
+
+        Labels are the union of every set containing the peptide::
+
+            ACDEF -> {ACDEF, EFGHI, HIKLM}
+            EFGHI -> {ACDEF, EFGHI, HIKLM, LMNPQ}
+            HIKLM -> {ACDEF, EFGHI, HIKLM, LMNPQ}
+            LMNPQ -> {EFGHI, HIKLM, LMNPQ}
+
+        THREE distinct labels: {ACDEF}, {EFGHI, HIKLM}, {LMNPQ}. The
+        two interior peptides sit in three neighbourhoods each, so both
+        take the full union and group together; the two terminal
+        peptides are singletons. Transitive closure would give a single
+        group and select ONE peptide instead of three.
+        """
+        adata = make_adata(
+            ["ACDEF", "EFGHI", "HIKLM", "LMNPQ"],
+            ["P1"] * 4,
+            [[10.0, 20.0, 99.0, 40.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF", "HIKLM", "LMNPQ"}
+
+    def test_chain_middle_group_records_both_members(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI", "HIKLM", "LMNPQ"],
+            ["P1"] * 4,
+            [[10.0, 20.0, 99.0, 40.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            inplace=False,
+            sort_descending_id=False,
+        )
+        provenance = dict(
+            zip(out.var_names, out.var["peptide_ids"]),
+        )
+        assert provenance["HIKLM"] == "EFGHI;HIKLM"
+        assert provenance["ACDEF"] == "ACDEF"
+        assert provenance["LMNPQ"] == "LMNPQ"
+
+    def test_non_overlapping_peptides_stay_separate(self):
+        adata = make_adata(
+            ["ACDEF", "RSTVWY"],
+            ["P1", "P1"],
+            [[10.0, 20.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF", "RSTVWY"}
+
+    def test_overlap_catches_what_substring_containment_misses(self):
+        """``ACDEF`` and ``EFGHI`` overlap at positions 4-5, yet neither
+        is a substring of the other. Substring containment would leave
+        them as two peptides; positional overlap collapses them."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"EFGHI"}
+
+    def test_grouping_is_confined_within_protein(self):
+        """Identical intervals in different proteins never group."""
+        adata = make_adata(
+            ["ACDEF", "ACDEFG"],
+            ["P1", "P2"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF", "ACDEFG"}
+
+    def test_peptidoforms_of_one_sequence_group_together(self):
+        """Two peptidoforms of one stripped sequence share an interval,
+        so they group and one is selected. This is why the reference
+        needs no separate modification-summarisation step."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+
+# -- Selection --------------------------------------------------------
+
+
+class TestSelection:
+    """``topN = 1`` SELECTS the most abundant member; it does not
+    aggregate."""
+
+    def test_most_abundant_is_selected_not_summed(self):
+        """Totals across samples: ACDEF = 1 + 2 = 3,
+        AC(UniMod:4)DEF = 10 + 20 = 30. The winner's own intensities
+        are returned -- NOT 11 and 22."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[1.0, 10.0], [2.0, 20.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+        np.testing.assert_array_equal(out.X, np.array([[10.0], [20.0]]))
+
+    def test_abundance_is_the_sum_across_all_samples(self):
+        """ACDEF wins on total (60) despite losing in sample 1."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 50.0], [50.0, 5.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF"}
+
+
+# -- Tie breaking -----------------------------------------------------
+
+
+class TestTieBreaking:
+    """Equal totals are resolved by ``tie_break_key``, never by input
+    order.
+
+    CCprofiler uses ``ties.method = "first"``, i.e. whichever row
+    happened to come first, which makes the output depend on how the
+    input table was sorted. A deterministic key removes that
+    dependency.
+
+    Measured on the reference dataset: of 26,473 groups, 4,752 have
+    more than one member and only 7 have a tied winner -- 6 of them
+    ties between two incomplete peptides, 1 a genuine equal-total tie.
+    Switching from row order to the default key changes the pick in 4
+    of the 7, and none of those 4 peptides reaches the reference's
+    24,534-peptide set, so the change costs nothing here. That margin
+    is dataset-specific; re-measure on new data.
+    """
+
+    def test_ties_are_broken_by_the_ordering_key(self):
+        """The default key sorts letters before any non-letter, so the
+        unmodified form wins a tie."""
+        adata = make_adata(
+            ["AC(UniMod:4)DEF", "ACDEF"],
+            ["P1", "P1"],
+            [[10.0, 10.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF"}
+
+    def test_tie_break_is_independent_of_input_order(self):
+        """The discriminating test: both input orders give the same
+        winner, which row-order tie-breaking cannot do."""
+        X = [[10.0, 10.0]]
+        one = summarize(
+            make_adata(
+                ["ACDEF", "AC(UniMod:4)DEF"],
+                ["P1", "P1"],
+                X,
+            ),
+            _FASTA,
+            inplace=False,
+        )
+        other = summarize(
+            make_adata(
+                ["AC(UniMod:4)DEF", "ACDEF"],
+                ["P1", "P1"],
+                X,
+            ),
+            _FASTA,
+            inplace=False,
+        )
+        assert survivors(one) == survivors(other) == {"ACDEF"}
+
+    def test_bracket_notation_also_sorts_after_letters(self):
+        adata = make_adata(
+            ["AC[+16]DEF", "ACDEF"],
+            ["P1", "P1"],
+            [[10.0, 10.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            mod_regex=r"\[.*?\]",
+            inplace=False,
+        )
+        assert survivors(out) == {"ACDEF"}
+
+    def test_letters_still_compare_alphabetically(self):
+        adata = make_adata(
+            ["EFGHI", "ACDEF"],
+            ["P1", "P1"],
+            [[10.0, 10.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF"}
+
+    def test_custom_tie_break_key_is_honoured(self):
+        """Longest-identifier-first instead of the default."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 10.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            tie_break_key=lambda pid: -len(pid),
+            inplace=False,
+        )
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+    def test_the_key_only_applies_to_equal_totals(self):
+        """Abundance decides first; the key never overrides it."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[1.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+
+# -- Output .var columns ----------------------------------------------
+
+
+class TestVarColumns:
+    """The surviving row's annotations are NOT representative of its
+    group, so they are not carried over.
+
+    Only two kinds of column survive: those a peptide-level proteodata
+    object requires, and those this function computes. Everything else
+    is dropped, because keeping it would invite the reader to treat one
+    member's metadata as the whole group's.
+    """
+
+    def test_var_holds_exactly_the_expected_columns(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert set(out.var.columns) == {
+            "peptide_id",
+            "protein_id",
+            "peptide_start",
+            "peptide_end",
+            "peptide_ids",
+            "n_grouped",
+        }
+
+    def test_extraneous_columns_are_dropped(self):
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[1.0, 10.0]],
+            var_extra={"charge": ["2", "3"], "gene_id": ["g1", "g2"]},
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert "charge" not in out.var.columns
+        assert "gene_id" not in out.var.columns
+
+    def test_dropping_happens_even_when_the_values_agree(self):
+        """``gene_id`` is identical across the group here, so carrying
+        it would be harmless -- and it is still dropped. The rule is
+        about provenance, not about whether a value happens to be
+        unambiguous."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[1.0, 10.0]],
+            var_extra={"gene_id": ["same", "same"]},
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert "gene_id" not in out.var.columns
+
+    def test_key_added_replaces_the_provenance_column_name(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            key_added="members",
+            inplace=False,
+        )
+        assert set(out.var.columns) == {
+            "peptide_id",
+            "protein_id",
+            "peptide_start",
+            "peptide_end",
+            "members",
+            "n_grouped",
+        }
+
+
+# -- Identifier naming ------------------------------------------------
+
+
+class TestNaming:
+    """``id_from`` selects how the surviving row is identified. Only
+    ``'top_ranked'`` is implemented; the parameter exists so that other
+    schemes can be added without a signature change."""
+
+    def test_default_names_the_row_after_the_top_ranked_member(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var_names.tolist() == ["EFGHI"]
+
+    def test_explicit_top_ranked_matches_the_default(self):
+        peptides, proteins = ["ACDEF", "EFGHI"], ["P1", "P1"]
+        X = [[10.0, 99.0]]
+        default = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            inplace=False,
+        )
+        explicit = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            id_from="top_ranked",
+            inplace=False,
+        )
+        assert default.var_names.tolist() == explicit.var_names.tolist()
+
+    def test_unknown_id_from_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="id_from"):
+            summarize(adata, _FASTA, id_from="joined", inplace=False)
+
+    def test_unknown_id_from_names_the_supported_value(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="top_ranked"):
+            summarize(adata, _FASTA, id_from="longest", inplace=False)
+
+
+# -- Provenance -------------------------------------------------------
+
+
+class TestProvenance:
+
+    def test_peptide_ids_lists_all_group_members_sorted(self):
+        adata = make_adata(
+            ["EFGHI", "ACDEF"],
+            ["P1", "P1"],
+            [[99.0, 10.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var["peptide_ids"].tolist() == ["ACDEF;EFGHI"]
+
+    def test_n_grouped_counts_group_members(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[10.0, 99.0, 5.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            inplace=False,
+            sort_descending_id=False,
+        )
+        counts = dict(zip(out.var_names, out.var["n_grouped"]))
+        assert counts == {"EFGHI": 2, "RSTVWY": 1}
+
+    def test_singleton_group_records_only_itself(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[10.0]])
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var["peptide_ids"].tolist() == ["ACDEF"]
+        assert out.var["n_grouped"].tolist() == [1]
+
+    def test_key_added_renames_the_provenance_column(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            key_added="members",
+            inplace=False,
+        )
+        assert out.var["members"].tolist() == ["ACDEF;EFGHI"]
+        assert "peptide_ids" not in out.var.columns
+
+    def test_provenance_survives_a_selection_it_did_not_win(self):
+        """The losing member is named even though its row is gone."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert "ACDEF" in out.var["peptide_ids"].iloc[0]
+        assert "ACDEF" not in survivors(out)
+
+
+# -- Guards against silently overwriting .var -------------------------
+
+
+class TestColumnGuards:
+    """Every column the function writes must be absent from the input
+    ``.var``, so a second call or a pre-existing annotation can never
+    be overwritten without the user noticing."""
+
+    def test_existing_peptide_start_raises(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"peptide_start": [99.0]},
+        )
+        with pytest.raises(ValueError, match="peptide_start"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_existing_peptide_end_raises(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"peptide_end": [99.0]},
+        )
+        with pytest.raises(ValueError, match="peptide_end"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_existing_provenance_column_raises(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"peptide_ids": ["stale"]},
+        )
+        with pytest.raises(ValueError, match="peptide_ids"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_existing_n_grouped_raises(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"n_grouped": [7]},
+        )
+        with pytest.raises(ValueError, match="n_grouped"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_key_added_avoids_a_provenance_collision(self):
+        """Renaming the output column is the documented way past a
+        clash on ``peptide_ids``."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"peptide_ids": ["stale", "stale"]},
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            key_added="members",
+            inplace=False,
+        )
+        assert out.var["members"].tolist() == ["ACDEF;EFGHI"]
+        # The stale column is no longer written to, so it is simply an
+        # extraneous annotation and is dropped like any other.
+        assert "peptide_ids" not in out.var.columns
+
+    def test_key_added_collision_is_also_guarded(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"members": ["stale"]},
+        )
+        with pytest.raises(ValueError, match="members"):
+            summarize(
+                adata,
+                _FASTA,
+                key_added="members",
+                inplace=False,
+            )
+
+    def test_calling_twice_raises_rather_than_overwriting(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        summarize(adata, _FASTA)
+        with pytest.raises(ValueError, match="peptide_start"):
+            summarize(adata, _FASTA)
+
+    def test_guard_message_points_at_the_remedy(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"peptide_start": [99.0]},
+        )
+        with pytest.raises(ValueError, match="drop"):
+            summarize(adata, _FASTA, inplace=False)
+
+
+# -- Missing-value policy ---------------------------------------------
+
+
+class TestMissingValues:
+    """Missing values are handled exactly as CCprofiler handles them,
+    with no parameter to choose otherwise.
+
+    ``proteinQuantification`` sums with ``na.rm = FALSE`` and ranks with
+    ``rank()``'s default ``na.last = TRUE``, so a peptide with any
+    missing sample has a ``NaN`` total and ranks LAST.
+
+    That is deprioritisation, not removal. A NaN-bearing peptide with no
+    complete competitor still wins its group and is passed through
+    untouched. The reference depends on this: its zero-variance step is
+    what finally removes such peptides, via ``var()`` propagating ``NA``.
+    """
+
+    def test_nan_input_is_accepted(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[np.nan, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.n_vars == 1
+
+    def test_nan_bearing_peptide_ranks_last(self):
+        """ACDEF would win on its observed values alone (100 > 10) but
+        loses because one of its samples is missing."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[100.0, 5.0], [np.nan, 5.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+    def test_even_a_far_weaker_complete_peptide_outranks_a_nan(self):
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[9999.0, 1.0], [np.nan, 1.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+    def test_nan_survives_when_it_has_no_competitor(self):
+        """A singleton group has nothing to lose to, so the NaN
+        survives and is passed through unchanged for a later
+        completeness filter to remove."""
+        adata = make_adata(["ACDEF"], ["P1"], [[np.nan], [5.0]])
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF"}
+        assert np.isnan(out.X[0, 0])
+
+    def test_all_nan_group_falls_back_to_the_ordering_key(self):
+        """Every member has a NaN total, so nothing separates them on
+        abundance and ``tie_break_key`` decides. This is the common
+        case: 6 of the 7 tied groups on the reference dataset are ties
+        between two incomplete peptides."""
+        adata = make_adata(
+            ["AC(UniMod:4)DEF", "ACDEF"],
+            ["P1", "P1"],
+            [[np.nan, np.nan]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert survivors(out) == {"ACDEF"}
+
+    def test_fill_na_zero_corrupts_the_ranking(self):
+        """Documents WHY ``fill_na=0`` is not faithful, so nobody
+        reintroduces it as a default. ACDEF has a missing sample, so
+        the reference ranks it last and keeps the complete competitor.
+        Zero-filling gives ACDEF a real total of 150, which beats 100,
+        and the wrong peptide survives."""
+        peptides, proteins = ["ACDEF", "AC(UniMod:4)DEF"], ["P1", "P1"]
+        X = [[150.0, 50.0], [np.nan, 50.0]]
+        faithful = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            inplace=False,
+        )
+        filled = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            fill_na=0,
+            inplace=False,
+        )
+        assert survivors(faithful) == {"AC(UniMod:4)DEF"}
+        assert survivors(filled) == {"ACDEF"}
+
+    def test_zero_to_na_makes_a_zero_bearing_peptide_lose(self):
+        """ACDEF wins on raw totals (100 > 55) but loses once its zero
+        is declared missing."""
+        peptides, proteins = ["ACDEF", "AC(UniMod:4)DEF"], ["P1", "P1"]
+        X = [[0.0, 50.0], [100.0, 5.0]]
+        raw = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            inplace=False,
+        )
+        masked = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            zero_to_na=True,
+            inplace=False,
+        )
+        assert survivors(raw) == {"ACDEF"}
+        assert survivors(masked) == {"AC(UniMod:4)DEF"}
+
+    def test_zero_to_na_is_inert_without_zeros(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[7.0]])
+        out = summarize(
+            adata,
+            _FASTA,
+            zero_to_na=True,
+            inplace=False,
+        )
+        np.testing.assert_array_equal(out.X, np.array([[7.0]]))
+
+    def test_zero_to_na_with_fill_na_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[0.0]])
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            summarize(
+                adata,
+                _FASTA,
+                zero_to_na=True,
+                fill_na=0,
+                inplace=False,
+            )
+
+    def test_nan_is_never_written_into_a_surviving_value(self):
+        """Selection copies a whole peptide's row, so at ``top_n=1`` no
+        arithmetic happens and NaN can be neither created nor spread.
+        It reaches the output only when the peptide that carried it
+        won."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[100.0, 5.0], [np.nan, 5.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert not np.isnan(out.X).any()
+
+
+# -- top_n and keep_less ----------------------------------------------
+
+
+class TestTopNAndKeepLess:
+
+    def test_top_n_two_sums_the_two_most_abundant(self):
+        """Group members total 30 and 10; their sum is 40 per sample."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 30.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        np.testing.assert_array_equal(out.X, np.array([[40.0]]))
+
+    def test_top_n_two_sums_only_the_top_two(self):
+        """Three peptidoforms of one interval; the weakest is dropped
+        from the sum, not merely from the identifier."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF", "AC(UniMod:35)DEF"],
+            ["P1", "P1", "P1"],
+            [[1.0, 30.0, 10.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        np.testing.assert_array_equal(out.X, np.array([[40.0]]))
+
+    def test_top_n_two_row_is_named_by_the_top_ranked_member(self):
+        """DELIBERATE DEVIATION from CCprofiler, which renames the row
+        to a comma-joined list of the summed identifiers and thereby
+        breaks its own annotation join. ``id_from='top_ranked'`` keeps
+        ``peptide_id`` a real peptide; the summed members remain
+        recoverable from the provenance column."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 30.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+        assert out.var["peptide_ids"].tolist() == [
+            "AC(UniMod:4)DEF;ACDEF",
+        ]
+
+    def test_keep_less_false_drops_undersized_groups(self):
+        """RSTVWY is a singleton, so it cannot supply two peptides."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[10.0, 30.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=False,
+            inplace=False,
+        )
+        assert survivors(out) == {"AC(UniMod:4)DEF"}
+
+    def test_keep_less_true_keeps_undersized_groups(self):
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[10.0, 30.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        assert survivors(out) == {"AC(UniMod:4)DEF", "RSTVWY"}
+
+    def test_keep_less_true_sums_what_the_group_has(self):
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[10.0, 30.0, 99.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+            sort_descending_id=False,
+        )
+        values = dict(zip(out.var_names, out.X[0]))
+        assert values == {"AC(UniMod:4)DEF": 40.0, "RSTVWY": 99.0}
+
+    def test_keep_less_is_inert_at_top_n_one(self):
+        """Every group has at least one member, so the filter cannot
+        remove anything. Pinned so the interaction is documented."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF", "RSTVWY"],
+            ["P1", "P1", "P1"],
+            [[10.0, 30.0, 99.0]],
+        )
+        strict = summarize(
+            adata,
+            _FASTA,
+            top_n=1,
+            keep_less=False,
+            inplace=False,
+        )
+        lenient = summarize(
+            adata,
+            _FASTA,
+            top_n=1,
+            keep_less=True,
+            inplace=False,
+        )
+        assert survivors(strict) == survivors(lenient)
+        np.testing.assert_array_equal(strict.X, lenient.X)
+
+    def test_top_n_below_one_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(ValueError, match="top_n"):
+            summarize(adata, _FASTA, top_n=0, inplace=False)
+
+
+# -- Output ordering --------------------------------------------------
+
+
+class TestOrdering:
+    """Row order is load-bearing: average-linkage clustering downstream
+    breaks ties by row order, so the reference's closing
+    ``setorder(traces, -id)`` must be reproducible."""
+
+    def test_output_is_ordered_by_descending_identifier(self):
+        adata = make_adata(
+            ["ACDEF", "RSTVWY", "LMNPQ"],
+            ["P1", "P1", "P1"],
+            [[1.0, 2.0, 3.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var_names.tolist() == ["RSTVWY", "LMNPQ", "ACDEF"]
+
+    def test_descending_order_can_be_disabled(self):
+        adata = make_adata(
+            ["ACDEF", "RSTVWY", "LMNPQ"],
+            ["P1", "P1", "P1"],
+            [[1.0, 2.0, 3.0]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            sort_descending_id=False,
+            inplace=False,
+        )
+        assert out.var_names.tolist() == ["ACDEF", "RSTVWY", "LMNPQ"]
+
+    def test_matrix_columns_follow_the_reordered_var(self):
+        adata = make_adata(
+            ["ACDEF", "RSTVWY", "LMNPQ"],
+            ["P1", "P1", "P1"],
+            [[1.0, 2.0, 3.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        values = dict(zip(out.var_names, out.X[0]))
+        assert values == {"ACDEF": 1.0, "RSTVWY": 2.0, "LMNPQ": 3.0}
+
+
+# -- API contract -----------------------------------------------------
+
+
+class TestContract:
+
+    def test_inplace_returns_none_and_mutates(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        assert summarize(adata, _FASTA) is None
+        assert survivors(adata) == {"EFGHI"}
+
+    def test_copy_leaves_the_input_untouched(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        summarize(adata, _FASTA, inplace=False)
+        assert adata.n_vars == 2
+        assert "peptide_start" not in adata.var.columns
+
+    def test_inplace_and_copy_agree(self):
+        peptides = ["ACDEF", "EFGHI", "RSTVWY"]
+        proteins = ["P1"] * 3
+        X = [[10.0, 99.0, 5.0]]
+        copied = summarize(
+            make_adata(peptides, proteins, X),
+            _FASTA,
+            inplace=False,
+        )
+        mutated = make_adata(peptides, proteins, X)
+        summarize(mutated, _FASTA)
+        assert mutated.var_names.tolist() == copied.var_names.tolist()
+        np.testing.assert_array_equal(mutated.X, copied.X)
+
+    def test_missing_peptide_column_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(KeyError, match="absent_col"):
+            summarize(
+                adata,
+                _FASTA,
+                peptide_col="absent_col",
+                inplace=False,
+            )
+
+    def test_missing_protein_column_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(KeyError, match="absent_col"):
+            summarize(
+                adata,
+                _FASTA,
+                protein_col="absent_col",
+                inplace=False,
+            )
+
+    def test_layers_are_dropped_from_the_output(self):
+        """The function reads and writes ``.X`` only. A layer cannot be
+        carried through honestly -- at ``top_n > 1`` the values are
+        summed, and summing someone else's matrix on their behalf would
+        be a guess -- so layers are discarded rather than silently
+        desynchronised from ``.X``."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        adata.layers["raw"] = np.array([[1.0, 2.0]])
+        out = summarize(adata, _FASTA, inplace=False)
+        assert not out.layers
+
+    def test_sparse_input_yields_sparse_output(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        adata.X = sparse.csr_matrix(adata.X)
+        out = summarize(adata, _FASTA, inplace=False)
+        assert sparse.issparse(out.X)
+        np.testing.assert_array_equal(
+            out.X.toarray(),
+            np.array([[99.0]]),
+        )
+
+    def test_output_passes_check_proteodata(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI", "RSTVWY"],
+            ["P1", "P1", "P2"],
+            [[10.0, 99.0, 5.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert check_proteodata(out)[0]
+
+    def test_peptide_id_column_matches_var_names(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var["peptide_id"].tolist() == out.var_names.tolist()
+
+    def test_obs_is_preserved(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0], [1.0, 2.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.obs_names.tolist() == ["s1", "s2"]
+
+    def test_empty_input_is_handled(self):
+        adata = make_adata([], [], np.empty((1, 0)))
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.n_vars == 0
+
+    def test_verbose_reports_the_peptide_reduction(self, capsys):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        summarize(adata, _FASTA, verbose=True, inplace=False)
+        assert "2" in capsys.readouterr().out

--- a/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
+++ b/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
@@ -1074,6 +1074,104 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
             "n_grouped",
         }
 
+    def test_keep_var_cols_retains_a_column(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"gene_id": ["Sorbs2", "Sorbs2"]},
+        )
+        out = summarize(
+            adata, _FASTA, keep_var_cols=["gene_id"], inplace=False
+        )
+        assert out.var["gene_id"].tolist() == ["Sorbs2"]
+
+    def test_kept_column_aggregates_over_the_whole_group(self):
+        """The survivor's own value is NOT used. Members that disagree
+        are joined, so the column describes the group rather than
+        whichever peptide happened to win."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"charge": ["2", "3"]},
+        )
+        out = summarize(adata, _FASTA, keep_var_cols=["charge"], inplace=False)
+        assert out.var["charge"].tolist() == ["2;3"]
+
+    def test_kept_column_collapses_when_members_agree(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"gene_id": ["same", "same"]},
+        )
+        out = summarize(
+            adata, _FASTA, keep_var_cols=["gene_id"], inplace=False
+        )
+        assert out.var["gene_id"].tolist() == ["same"]
+
+    def test_keep_var_cols_extends_the_column_set(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"gene_id": ["g", "g"], "charge": ["2", "3"]},
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            keep_var_cols=["gene_id", "charge"],
+            inplace=False,
+        )
+        assert set(out.var.columns) == {
+            "peptide_id",
+            "protein_id",
+            "peptide_start",
+            "peptide_end",
+            "peptide_ids",
+            "n_grouped",
+            "gene_id",
+            "charge",
+        }
+
+    def test_unlisted_columns_are_still_dropped(self):
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+            var_extra={"gene_id": ["g", "g"], "charge": ["2", "3"]},
+        )
+        out = summarize(
+            adata, _FASTA, keep_var_cols=["gene_id"], inplace=False
+        )
+        assert "charge" not in out.var.columns
+
+    def test_keep_var_cols_unknown_column_raises(self):
+        adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
+        with pytest.raises(KeyError, match="absent_col"):
+            summarize(
+                adata,
+                _FASTA,
+                keep_var_cols=["absent_col"],
+                inplace=False,
+            )
+
+    def test_keep_var_cols_cannot_name_a_written_column(self):
+        adata = make_adata(
+            ["ACDEF"],
+            ["P1"],
+            [[1.0]],
+            var_extra={"gene_id": ["g"]},
+        )
+        with pytest.raises(ValueError, match="n_grouped"):
+            summarize(
+                adata,
+                _FASTA,
+                keep_var_cols=["gene_id", "n_grouped"],
+                inplace=False,
+            )
+
     # -- Identifier naming ------------------------------------------------
 
     # (was class TestNaming)

--- a/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
+++ b/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
@@ -1654,6 +1654,41 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
         assert survivors(strict) == survivors(lenient)
         np.testing.assert_array_equal(strict.X, lenient.X)
 
+    def test_summation_propagates_missing_values(self):
+        """At ``top_n > 1`` the contributors are summed, and the sum
+        propagates: a sample missing in any contributor is missing in
+        the result. Sample 1 is complete in both members; sample 2 is
+        missing in one."""
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[10.0, 30.0], [5.0, np.nan]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        assert out.X[0, 0] == 40.0
+        assert np.isnan(out.X[1, 0])
+
+    def test_all_missing_group_sums_to_missing(self):
+        adata = make_adata(
+            ["ACDEF", "AC(UniMod:4)DEF"],
+            ["P1", "P1"],
+            [[np.nan, np.nan]],
+        )
+        out = summarize(
+            adata,
+            _FASTA,
+            top_n=2,
+            keep_less=True,
+            inplace=False,
+        )
+        assert np.isnan(out.X).all()
+
     def test_top_n_below_one_raises(self):
         adata = make_adata(["ACDEF"], ["P1"], [[1.0]])
         with pytest.raises(ValueError, match="top_n"):
@@ -1772,7 +1807,11 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
         out = summarize(adata, _FASTA, inplace=False)
         assert not out.layers
 
-    def test_sparse_input_yields_sparse_output(self):
+    def test_sparse_input_is_densified(self):
+        """A peptide intensity matrix is not meaningfully sparse -- an
+        absent measurement is missing, not zero -- and the algorithm
+        ranks and reorders whole columns, so nothing is gained by
+        preserving the format."""
         adata = make_adata(
             ["ACDEF", "EFGHI"],
             ["P1", "P1"],
@@ -1780,11 +1819,8 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
         )
         adata.X = sparse.csr_matrix(adata.X)
         out = summarize(adata, _FASTA, inplace=False)
-        assert sparse.issparse(out.X)
-        np.testing.assert_array_equal(
-            out.X.toarray(),
-            np.array([[99.0]]),
-        )
+        assert not sparse.issparse(out.X)
+        np.testing.assert_array_equal(out.X, np.array([[99.0]]))
 
     def test_output_passes_check_proteodata(self):
         adata = make_adata(
@@ -1816,6 +1852,42 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
         )
         out = summarize(adata, _FASTA, inplace=False)
         assert out.var.index.name is None
+
+    def test_protein_level_input_raises(self):
+        """The function is peptide-level only: it needs a peptide
+        identifier to locate in a protein sequence."""
+        var = pd.DataFrame({"protein_id": ["P1"]}, index=["P1"])
+        obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
+        adata = AnnData(X=np.array([[1.0]]), obs=obs, var=var)
+        with pytest.raises((KeyError, ValueError), match="peptide"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_var_names_out_of_sync_raises(self):
+        """`peptide_id` present but not matching `.var_names`, so the
+        object is not peptide-level proteodata."""
+        var = pd.DataFrame(
+            {"peptide_id": ["ACDEF"], "protein_id": ["P1"]},
+            index=["something_else"],
+        )
+        obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
+        adata = AnnData(X=np.array([[1.0]]), obs=obs, var=var)
+        with pytest.raises(ValueError, match="peptide-level"):
+            summarize(adata, _FASTA, inplace=False)
+
+    def test_multi_mapped_peptide_raises(self):
+        """One peptide mapping to two proteins is not peptide-level
+        proteodata either."""
+        var = pd.DataFrame(
+            {
+                "peptide_id": ["ACDEF", "ACDEF"],
+                "protein_id": ["P1", "P2"],
+            },
+            index=["ACDEF", "ACDEF"],
+        )
+        obs = pd.DataFrame({"sample_id": ["s1"]}, index=["s1"])
+        adata = AnnData(X=np.array([[1.0, 2.0]]), obs=obs, var=var)
+        with pytest.raises(ValueError):
+            summarize(adata, _FASTA, inplace=False)
 
     def test_obs_is_preserved(self):
         adata = make_adata(

--- a/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
+++ b/tests/pp/test_summarize_peptides_by_neighbourhood_union.py
@@ -1706,6 +1706,19 @@ class TestSummarizePeptidesByNeighbourhoodUnion:
         out = summarize(adata, _FASTA, inplace=False)
         assert out.var["peptide_id"].tolist() == out.var_names.tolist()
 
+    def test_var_index_is_unnamed(self):
+        """A named var index turns ``.reset_index()`` into a
+        differently-named column, which breaks the COPF tools
+        downstream. Caught only by running the pipeline, so pinned
+        here."""
+        adata = make_adata(
+            ["ACDEF", "EFGHI"],
+            ["P1", "P1"],
+            [[10.0, 99.0]],
+        )
+        out = summarize(adata, _FASTA, inplace=False)
+        assert out.var.index.name is None
+
     def test_obs_is_preserved(self):
         adata = make_adata(
             ["ACDEF", "EFGHI"],


### PR DESCRIPTION
Adds `pr.pp.summarize_peptides_by_neighbourhood_union()`, which collapses peptides that overlap in the protein sequence and keeps the most abundant member of each group. Peptide positions are resolved from a FASTA in the same call, so no separate annotation step is needed.

A reimplementation of CCprofiler's `summarizeAlternativePeptideSequences(topN = 1)` ([branch `proteoformLocationMapping`](https://github.com/CCprofiler/CCprofiler/tree/proteoformLocationMapping)).

`summarize_overlapping_peptides` is untouched.

### Why a separate function

|  | `summarize_overlapping_peptides` | this |
| --- | --- | --- |
| groups by | substring containment | position in the protein sequence |
| reduces by | aggregating the members | selecting among them |

Positional overlap sees pairs that containment cannot: two peptides can overlap in the protein while neither contains the other. It also needs no separate modification-summarisation step, since two peptidoforms of one stripped sequence share an interval and therefore a group.

### Behaviour worth a look during review

- **Missing values are deprioritised, not removed.** A peptide with any missing sample sorts last and loses to any complete competitor; with no complete member in the group it still wins and passes through untouched. At `top_n > 1` the sum propagates missingness.
- **Ties are resolved by `tie_break_key`**, not by input row order, so the result does not depend on how the input table happened to be sorted. The default places non-letters after letters, favouring the unmodified form of an identifier.
- **`mod_regex` is self-checking.** Whatever remains after stripping must be amino acids, so an uncovered mass shift, bracket tag or lowercase marker raises instead of silently producing an unlocatable peptide. The default alphabet is the IUPAC set, which admits selenocysteine and the ambiguity codes.
- **`on_unknown_protein` and `on_unlocated_peptide`** each take `{"raise", "skip", "keep"}` and default to `"raise"`.
- **`.var` is reduced** to the peptide-level proteodata columns plus the function's own output. The surviving row's other annotations describe one member rather than the group, so carrying them would invite them to be read as representative; `keep_var_cols` carries chosen columns through, aggregated across the group.
- **Columns the function writes must be absent from the input**, so a second call raises rather than overwriting. The function is therefore not idempotent by design.
- Peptide-level proteodata only. Sparse `.X` is densified; output `.X` is always dense.

### Tests

128 tests, written before the implementation, with every expected value derived by hand from a synthetic twenty-residue protein. Several exist specifically to stop faithful-but-surprising behaviour being "corrected" later — the one-hop union rather than a transitive closure, the empty-label collapse of unlocated peptides, and the missing-value ranking. The docstring example runs as a doctest. Full suite green at 449.

### Also

- `docs/sphinx/source/api/pp.rst`: listed under Quantification.
- `HISTORY.md`: `Added` entry under `[Unreleased]`.

Unrelated, noted in passing: the Sphinx build currently aborts on `main` with a `SEVERE: Unexpected section title` from `sphinx_autodoc_typehints`, before any HTML is written. It reproduces without this branch and is not addressed here.
